### PR TITLE
CI/CD Cache

### DIFF
--- a/.github/workflows/msvc-2019-windows-x64.yml
+++ b/.github/workflows/msvc-2019-windows-x64.yml
@@ -15,28 +15,54 @@ jobs:
         build_mode: ["Release", "Debug"]
 
     steps:
+      - name: Checkout code
       - uses: actions/checkout@v3
 
-      - name: Install Vulkan SDK
-        uses: humbletim/install-vulkan-sdk@v1.1.1
+      - name: Cache and Install Dependencies
+        id: cache-and-install
+        uses: actions/cache@v3
         with:
-          version: latest
-          cache: true
-    
+          path: |
+            VULKAN_SDK
+            SDL/build
+            SDL/include
+            vcpkg
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+      
+      - name: Install Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        with:
+          vulkan-query-version: 1.3.204.0
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true  
+        if: steps.cache-and-install.outputs.cache-hit != 'true
+      
       - name: Install SDL3
-        run: git clone https://github.com/libsdl-org/SDL.git && cd SDL && mkdir build && cd build && cmake .. -DSDL_STATIC=ON && cmake --build . --config Release --target install
+        run: |
+          git clone https://github.com/libsdl-org/SDL
+          cd SDL && mkdir build
+          cd build && cmake .. -DSDL_STATIC=ON
+          cmake --build . --config Release
+        if: steps.cache-and-install.outputs.cache-hit != 'true 
 
       - name: Install vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git && cd vcpkg && ./bootstrap-vcpkg.bat
+        env:
+          VULKAN_SDK: ${{ github.workspace }}/VULKAN_SDK
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git
+          cd vcpkg && ./bootstrap-vcpkg.bat
+          vcpkg integrate install
+          vcpkg install --triplet x64-windows vulkan freetype libpng[apng] harfbuzz fmt libwebp libjpeg-turbo libpng spdlog simdjson gtest libogg ffmpeg libavif curl
+        if: steps.cache-and-install.outputs.cache-hit != 'true  
 
-      - name: Install dependencies via vcpkg
-        run: cd vcpkg && .\vcpkg.exe install --triplet x64-windows vulkan freetype libpng[apng] harfbuzz fmt libwebp libjpeg-turbo libpng spdlog simdjson gtest libogg ffmpeg libavif
-
-      - name: Configure Build Directory
-        run: mkdir build && cd build && cmake .. -DCMAKE_TOOLCHAIN_FILE="../vcpkg/scripts/buildsystems/vcpkg.cmake" -DSTX_ENABLE_BACKTRACE=OFF
-
-      - name: Build Ashura
-        run: cd build && cmake --build . --config ${{matrix.build_mode}}
+      - name: Configure and build Ashura
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+          cmake --build . --config ${{matrix.build_mode}}
 
       - name: Run Ashura Test
         run: cd build/ashura/${{matrix.build_mode}}/ && ./ashura_test.exe

--- a/.github/workflows/msvc-2019-windows-x64.yml
+++ b/.github/workflows/msvc-2019-windows-x64.yml
@@ -54,7 +54,8 @@ jobs:
           git clone https://github.com/microsoft/vcpkg.git
           cd vcpkg && ./bootstrap-vcpkg.bat
           vcpkg integrate install
-          vcpkg install --triplet x64-windows vulkan freetype libpng[apng] harfbuzz fmt libwebp libjpeg-turbo libpng spdlog simdjson gtest libogg ffmpeg libavif curl
+          copy ..\vcpkg.json .
+          vcpkg install --triplet x64-windows 
         if: steps.cache-and-install.outputs.cache-hit != 'true  
 
       - name: Configure and build Ashura

--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ Ashura is a 2D Retained-Mode GUI and 3D Framework for use in GUI applications an
 - Install MSVC, Clang, or GCC with C++20 support
 - Install CMake (>= 3.1)
 - Install [SDL 3](https://github.com/libsdl-org/SDL) with SDL_STATIC=ON to generate the SDL3-static target
-- Install dependencies using vcpkg, for example for an x64 target:
-```bash
-vcpkg install --triplet x64-windows vulkan freetype libpng[apng] harfbuzz fmt libwebp libjpeg-turbo libpng spdlog simdjson gtest libogg ffmpeg libavif curl
-```
 
 ## Building
 - Build the project using (where ${PATH_TO_ASHURA} is replaced with the path to this project and ${PATH_TO_VCPKG} is replaced with the path to your vcpkg installation): 

--- a/ashura/src/subsystems/http_client.cc
+++ b/ashura/src/subsystems/http_client.cc
@@ -23,7 +23,7 @@ HttpCurlMultiHandle::HttpCurlMultiHandle(CURLM *init_multi) :
   if (init_multi)
     impl = new HttpCurlMultiHandleImpl(init_multi);
   else
-    throw std::runtime_error("Invalid multi-handle provided.");
+    stx::panic("Invalid multi-handle provided.");
 }
 
 HttpCurlMultiHandle::~HttpCurlMultiHandle()
@@ -54,7 +54,7 @@ HttpCurlEasyHandle::HttpCurlEasyHandle(CURL *easy, curl_slist *header, stx::Rc<H
     impl(new HttpCurlEasyHandleImpl(easy, header, std::move(parent)))
 {
   if (!impl->easy)
-    throw std::runtime_error("Failed to initialize HttpCurlEasyHandle.");
+    stx::panic("Failed to initialize HttpCurlEasyHandle");
 }
 
 inline size_t curl_header_write_function(u8 const *bytes, size_t unit_size,

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,24 @@
+{
+    "name": "ashura",
+    "version": "1.0.0",
+    "dependencies": [
+        {
+            "name": "libpng",
+            "features": [ "apng" ]          
+        },
+        "vulkan",
+        "fmt",
+        "freetype",
+        "harfbuzz",
+        "libwebp",
+        "libjpeg-turbo",
+        "libpng",
+        "spdlog",
+        "simdjson",
+        "gtest",
+        "libogg",
+        "ffmpeg",
+        "libavif",
+        "curl"
+    ]
+}


### PR DESCRIPTION
- Migrated to Vcpkg manifest mode to enhance caching of dependencies on updates 
- manifest mode also eliminates the need for manual dependency installations when building.
