### PR TITLE
Slang Migration Finish-Up

### DIFF
--- a/ashura/engine/gpu_system.cc
+++ b/ashura/engine/gpu_system.cc
@@ -929,11 +929,11 @@ TextureId GpuSystem::alloc_texture_id(gpu::ImageView view)
     device_->update_descriptor_set(gpu::DescriptorSetUpdate{
       .set     = textures_,
       .binding = 0,
-      .element = (u16) i,
+      .element = (u32) i,
       .images  = span({gpu::ImageBinding{.image_view = view}})});
   });
 
-  return TextureId{(u16) i};
+  return TextureId{(u32) i};
 }
 
 void GpuSystem::release_texture_id(TextureId id)
@@ -956,11 +956,11 @@ SamplerId GpuSystem::alloc_sampler_id(gpu::Sampler sampler)
     device_->update_descriptor_set(gpu::DescriptorSetUpdate{
       .set     = samplers_,
       .binding = 0,
-      .element = (u16) i,
+      .element = (u32) i,
       .images  = span({gpu::ImageBinding{.sampler = sampler}})});
   });
 
-  return SamplerId{(u16) i};
+  return SamplerId{(u32) i};
 }
 
 void GpuSystem::release_sampler_id(SamplerId id)

--- a/ashura/engine/gpu_system.h
+++ b/ashura/engine/gpu_system.h
@@ -11,7 +11,7 @@ namespace ash
 {
 
 /// @details do not change the underlying type. It maps directly to the GPU handle
-enum class TextureId : u16
+enum class TextureId : u32
 {
   Base        = 0,
   White       = 0,
@@ -26,10 +26,10 @@ enum class TextureId : u16
   Yellow      = 9
 };
 
-inline constexpr u16 NUM_DEFAULT_TEXTURES = 10;
+inline constexpr u32 NUM_DEFAULT_TEXTURES = 10;
 
 /// @details do not change the underlying type. It maps directly to the GPU handle
-enum class SamplerId : u16
+enum class SamplerId : u32
 {
   Linear         = 0,
   Nearest        = 1,
@@ -37,7 +37,7 @@ enum class SamplerId : u16
   NearestClamped = 3
 };
 
-inline constexpr u16 NUM_DEFAULT_SAMPLERS = 4;
+inline constexpr u32 NUM_DEFAULT_SAMPLERS = 4;
 
 struct Framebuffer
 {
@@ -375,9 +375,9 @@ struct GpuSystem
     gpu::Format::D16_UNORM_S8_UINT, gpu::Format::D24_UNORM_S8_UINT,
     gpu::Format::D32_SFLOAT_S8_UINT};
 
-  static constexpr u16 NUM_TEXTURE_SLOTS = 2'048;
+  static constexpr u32 NUM_TEXTURE_SLOTS = 2'048;
 
-  static constexpr u16 NUM_SAMPLER_SLOTS = 128;
+  static constexpr u32 NUM_SAMPLER_SLOTS = 128;
 
   static constexpr u16 NUM_FRAME_TIMESPANS = 2'048;
 

--- a/ashura/engine/passes.cc
+++ b/ashura/engine/passes.cc
@@ -34,9 +34,7 @@ void BlurPass::acquire()
   // Algorithm described here:
   // https://community.arm.com/cfs-file/__key/communityserver-blogs-components-weblogfiles/00-00-00-20-66/siggraph2015_2D00_mmg_2D00_marius_2D00_slides.pdf
   //
-  gpu::Shader vertex_shader = sys->shader.get("VS:Blur/DownSample"_str).shader;
-  gpu::Shader fragment_shader =
-    sys->shader.get("FS:Blur/DownSample"_str).shader;
+  gpu::Shader shader = sys->shader.get("Blur"_str).shader;
 
   gpu::RasterizationState raster_state{.depth_clamp_enable = false,
                                        .polygon_mode = gpu::PolygonMode::Fill,
@@ -79,14 +77,14 @@ void BlurPass::acquire()
 
   gpu::GraphicsPipelineInfo pipeline_info{
     .label         = "Blur Graphics Pipeline"_str,
-    .vertex_shader = gpu::ShaderStageInfo{.shader      = vertex_shader,
-                                          .entry_point = "main"_str,
+    .vertex_shader = gpu::ShaderStageInfo{.shader      = shader,
+                                          .entry_point = "vs_main"_str,
                                           .specialization_constants      = {},
                                           .specialization_constants_data = {}},
     .fragment_shader =
-      gpu::ShaderStageInfo{.shader                        = fragment_shader,
-                                          .entry_point                   = "main"_str,
-                                          .specialization_constants      = {},
+      gpu::ShaderStageInfo{.shader                   = shader,
+                                          .entry_point              = "fs_downsample_main"_str,
+                                          .specialization_constants = {},
                                           .specialization_constants_data = {}},
     .color_formats          = {&sys->gpu.color_format_, 1},
     .vertex_input_bindings  = {},
@@ -103,10 +101,7 @@ void BlurPass::acquire()
   downsample_pipeline =
     sys->gpu.device_->create_graphics_pipeline(pipeline_info).unwrap();
 
-  pipeline_info.vertex_shader.shader =
-    sys->shader.get("VS:Blur/UpSample"_str).shader;
-  pipeline_info.fragment_shader.shader =
-    sys->shader.get("FS:Blur/UpSample"_str).shader;
+  pipeline_info.fragment_shader.entry_point = "fs_upsample_main"_str;
 
   upsample_pipeline =
     sys->gpu.device_->create_graphics_pipeline(pipeline_info).unwrap();
@@ -243,8 +238,7 @@ Option<FramebufferResult> BlurPass::encode(gpu::CommandEncoder &  e,
 
 void NgonPass::acquire()
 {
-  gpu::Shader vertex_shader   = sys->shader.get("VS:Ngon"_str).shader;
-  gpu::Shader fragment_shader = sys->shader.get("FS:Ngon"_str).shader;
+  gpu::Shader shader = sys->shader.get("Ngon"_str).shader;
 
   gpu::RasterizationState raster_state{.depth_clamp_enable = false,
                                        .polygon_mode = gpu::PolygonMode::Fill,
@@ -289,13 +283,13 @@ void NgonPass::acquire()
 
   gpu::GraphicsPipelineInfo pipeline_info{
     .label         = "Ngon Graphics Pipeline"_str,
-    .vertex_shader = gpu::ShaderStageInfo{.shader      = vertex_shader,
-                                          .entry_point = "main"_str,
+    .vertex_shader = gpu::ShaderStageInfo{.shader      = shader,
+                                          .entry_point = "vs_main"_str,
                                           .specialization_constants      = {},
                                           .specialization_constants_data = {}},
     .fragment_shader =
-      gpu::ShaderStageInfo{.shader                        = fragment_shader,
-                                          .entry_point                   = "main"_str,
+      gpu::ShaderStageInfo{.shader                        = shader,
+                                          .entry_point                   = "fs_main"_str,
                                           .specialization_constants      = {},
                                           .specialization_constants_data = {}},
     .color_formats          = {&sys->gpu.color_format_, 1},
@@ -366,8 +360,7 @@ void NgonPass::release()
 
 void PBRPass::acquire()
 {
-  gpu::Shader vertex_shader   = sys->shader.get("VS:PBR"_str).shader;
-  gpu::Shader fragment_shader = sys->shader.get("FS:PBR"_str).shader;
+  gpu::Shader shader = sys->shader.get("PBR"_str).shader;
 
   gpu::RasterizationState raster_state{.depth_clamp_enable = false,
                                        .polygon_mode = gpu::PolygonMode::Fill,
@@ -413,13 +406,13 @@ void PBRPass::acquire()
 
   gpu::GraphicsPipelineInfo pipeline_info{
     .label         = "PBR Graphics Pipeline"_str,
-    .vertex_shader = gpu::ShaderStageInfo{.shader      = vertex_shader,
-                                          .entry_point = "main"_str,
+    .vertex_shader = gpu::ShaderStageInfo{.shader      = shader,
+                                          .entry_point = "vs_main"_str,
                                           .specialization_constants      = {},
                                           .specialization_constants_data = {}},
     .fragment_shader =
-      gpu::ShaderStageInfo{.shader                        = fragment_shader,
-                                          .entry_point                   = "main"_str,
+      gpu::ShaderStageInfo{.shader                        = shader,
+                                          .entry_point                   = "fs_main"_str,
                                           .specialization_constants      = {},
                                           .specialization_constants_data = {}},
     .color_formats          = {&sys->gpu.color_format_, 1},
@@ -503,8 +496,7 @@ void PBRPass::release()
 
 void RRectPass::acquire()
 {
-  gpu::Shader vertex_shader   = sys->shader.get("VS:RRect"_str).shader;
-  gpu::Shader fragment_shader = sys->shader.get("FS:RRect"_str).shader;
+  gpu::Shader shader = sys->shader.get("RRect"_str).shader;
 
   gpu::RasterizationState raster_state{.depth_clamp_enable = false,
                                        .polygon_mode = gpu::PolygonMode::Fill,
@@ -549,13 +541,13 @@ void RRectPass::acquire()
 
   gpu::GraphicsPipelineInfo pipeline_info{
     .label         = "RRect Graphics Pipeline"_str,
-    .vertex_shader = gpu::ShaderStageInfo{.shader      = vertex_shader,
-                                          .entry_point = "main"_str,
+    .vertex_shader = gpu::ShaderStageInfo{.shader      = shader,
+                                          .entry_point = "vs_main"_str,
                                           .specialization_constants      = {},
                                           .specialization_constants_data = {}},
     .fragment_shader =
-      gpu::ShaderStageInfo{.shader                        = fragment_shader,
-                                          .entry_point                   = "main"_str,
+      gpu::ShaderStageInfo{.shader                        = shader,
+                                          .entry_point                   = "fs_main"_str,
                                           .specialization_constants      = {},
                                           .specialization_constants_data = {}},
     .color_formats          = {&sys->gpu.color_format_, 1},

--- a/ashura/engine/passes.h
+++ b/ashura/engine/passes.h
@@ -165,7 +165,7 @@ struct PBRParam
   TextureId clearcoat_map           = TextureId::White;
   TextureId clearcoat_roughness_map = TextureId::White;
   TextureId clearcoat_normal_map    = TextureId::White;
-  u16       first_light             = 0;
+  u32       first_light             = 0;
   u32       first_vertex            = 0;
 };
 

--- a/ashura/shaders/blur.slang
+++ b/ashura/shaders/blur.slang
@@ -8,17 +8,17 @@ struct BlurParam
 {
   f32x2 uv[2];
   f32x2 radius;
-  u16   sampler;
-  u16   tex;
+  u32   sampler;
+  u32   tex;
 };
 
 [[vk::push_constant]]
-BlurParam p;
+ConstantBuffer<BlurParam, Std430DataLayout> p;
 
 [[vk::binding(0, 0)]]
 SamplerState samplers[];
 
-[[vk::binding(1, 0)]]
+[[vk::binding(0, 1)]]
 Texture2D textures[];
 
 static constexpr f32x2 VERTEX_BUFFER[] = {f32x2(-0.5, -0.5), f32x2(0.5, -0.5),
@@ -26,33 +26,33 @@ static constexpr f32x2 VERTEX_BUFFER[] = {f32x2(-0.5, -0.5), f32x2(0.5, -0.5),
 
 struct VertexOutput
 {
-  f32x2 uv : UV_COORD;
-  f32x4 position : SV_Position;
+  f32x4                     position : SV_Position;
+  [[vk::location(0)]] f32x2 uv : UV_COORD;
 };
 
 [[shader("vertex")]]
-VertexOutput vs_main(uint32_t vertex_idx : SV_VertexID)
+VertexOutput vs_main(u32 vertex_idx : SV_VertexID)
 {
   f32x2 local_pos = VERTEX_BUFFER[vertex_idx];
-  return VertexOutput(local_pos + 0.5, f32x4(local_pos * 2, 0, 1));
+  return VertexOutput(f32x4(local_pos * 2, 0, 1), local_pos + 0.5);
 }
 
 [[shader("fragment")]]
-f32x4 fs_upsample_main(f32x2 uv : UV_COORD) :
+f32x4 fs_upsample_main([[vk::location(0)]] f32x2 uv : UV_COORD) :
   COLOR
 {
   var tex_uv = lerp(p.uv[0], p.uv[1], uv);
-  return upsample_clamped(samplers[NonUniformResourceIndex((uint) p.sampler)],
-                          textures[NonUniformResourceIndex((uint) p.tex)],
-                          tex_uv, p.radius, p.uv[0], p.uv[1]);
+  return upsample_clamped(samplers[NonUniformResourceIndex(p.sampler)],
+                          textures[NonUniformResourceIndex(p.tex)], tex_uv,
+                          p.radius, p.uv[0], p.uv[1]);
 }
 
 [[shader("fragment")]]
-f32x4 fs_downsample_main(f32x2 uv : UV_COORD) :
+f32x4 fs_downsample_main([[vk::location(0)]] f32x2 uv : UV_COORD) :
   COLOR
 {
   var tex_uv = lerp(p.uv[0], p.uv[1], uv);
-  return downsample_clamped(samplers[NonUniformResourceIndex((uint) p.sampler)],
-                            textures[NonUniformResourceIndex((uint) p.tex)],
-                            tex_uv, p.radius, p.uv[0], p.uv[1]);
+  return downsample_clamped(samplers[NonUniformResourceIndex(p.sampler)],
+                            textures[NonUniformResourceIndex(p.tex)], tex_uv,
+                            p.radius, p.uv[0], p.uv[1]);
 }

--- a/ashura/shaders/modules/core.slang
+++ b/ashura/shaders/modules/core.slang
@@ -4,9 +4,9 @@
 
 #include "types.slang"
 
-static constexpr f32 PI      = 3.1415926535897932384626433832795;
-static constexpr f32 GAMMA   = 2.2;
-static constexpr f32 EPSILON = 0.00000011920929;
+static const f32 PI      = 3.1415926535897932384626433832795;
+static const f32 GAMMA   = 2.2;
+static const f32 EPSILON = 0.00000011920929;
 
 f32x3 pow_v(f32x3 v, f32 p)
 {

--- a/ashura/shaders/modules/types.slang
+++ b/ashura/shaders/modules/types.slang
@@ -2,9 +2,7 @@
 
 #pragma once
 
-typedef uint16_t  u16;
 typedef uint32_t  u32;
-typedef int16_t   i16;
 typedef int32_t   i32;
 typedef float4    f32x4;
 typedef float3    f32x3;

--- a/ashura/shaders/ngon.slang
+++ b/ashura/shaders/ngon.slang
@@ -10,34 +10,35 @@ struct NgonParam
   f32x4             tint[4];
   f32x4             uv;
   f32               tiling;
-  u16               sampler;
-  u16               albedo;
+  u32               sampler;
+  u32               albedo;
   u32               first_index;
   u32               first_vertex;
 };
 
 [[vk::push_constant]]
-f32x4x4 world_to_view;
+ConstantBuffer<f32x4x4> world_to_view;
 
 [[vk::binding(0, 0)]]
 StructuredBuffer<f32x2> vtx_buffer;
 
-[[vk::binding(1, 0)]]
+[[vk::binding(0, 1)]]
 StructuredBuffer<u32> idx_buffer;
 
-[[vk::binding(2, 0)]]
+[[vk::binding(0, 2)]]
 StructuredBuffer<NgonParam> params;
 
-[[vk::binding(3, 0)]]
+[[vk::binding(0, 3)]]
 SamplerState samplers[];
 
-[[vk::binding(4, 0)]]
+[[vk::binding(0, 4)]]
 Texture2D textures[];
 
 struct VertexOutput
 {
-  f32x2 uv : UV_COORD;
-  f32x4 position : SV_Position;
+  f32x4                                   position : SV_Position;
+  [[vk::location(0)]] nointerpolation u32 instance : INSTANCE;
+  [[vk::location(1)]] f32x2               uv : UV_COORD;
 };
 
 [[shader("vertex")]]
@@ -47,17 +48,18 @@ VertexOutput vs_main(u32 instance : SV_InstanceID, u32 vertex : SV_VertexID)
   var idx = idx_buffer[p.first_index + vertex];
   var pos = vtx_buffer[p.first_vertex + idx];
   return VertexOutput(
-    pos + 0.5, mul(world_to_view, mul(p.transform, f32x4(pos, 0.0, 1.0))));
+    mul(world_to_view, mul(p.transform, f32x4(pos, 0.0, 1.0))), instance,
+    pos + 0.5);
 }
 
 [[shader("fragment")]]
-f32x4 fs_main(u32 instance : SV_InstanceID, f32x2 uv : UV_COORD) :
+f32x4 fs_main([[vk::location(0)]] u32   instance : INSTANCE,
+              [[vk::location(1)]] f32x2 uv : UV_COORD) :
   COLOR
 {
   var p      = params[instance];
   var tex_uv = lerp(p.uv.xy, p.uv.zw, uv);
   return bilerp(p.tint, uv) *
-         textures[NonUniformResourceIndex((uint) p.albedo)].Sample(
-           samplers[NonUniformResourceIndex((uint) p.sampler)],
-           tex_uv * p.tiling);
+         textures[NonUniformResourceIndex(p.albedo)].Sample(
+           samplers[NonUniformResourceIndex(p.sampler)], tex_uv * p.tiling);
 }

--- a/ashura/shaders/pbr.slang
+++ b/ashura/shaders/pbr.slang
@@ -32,17 +32,17 @@ struct PbrExtParam
   f32                clearcoat;
   f32                clearcoat_roughness;
   f32                clearcoat_normal;
-  u16                sampler;
-  u16                albedo_map;
-  u16                metallic_map;
-  u16                roughness_map;
-  u16                normal_map;
-  u16                occlusion_map;
-  u16                emissive_map;
-  u16                clearcoat_map;
-  u16                clearcoat_roughness_map;
-  u16                clearcoat_normal_map;
-  u16                first_light;
+  u32                sampler;
+  u32                albedo_map;
+  u32                metallic_map;
+  u32                roughness_map;
+  u32                normal_map;
+  u32                occlusion_map;
+  u32                emissive_map;
+  u32                clearcoat_map;
+  u32                clearcoat_roughness_map;
+  u32                clearcoat_normal_map;
+  u32                first_light;
   u32                first_vertex;
 };
 
@@ -98,31 +98,32 @@ struct Vertex
 };
 
 [[vk::push_constant]]
-float4x4 world_to_view;
+ConstantBuffer<float4x4, Std430DataLayout> world_to_view;
 
 [[vk::binding(0, 0)]]
 StructuredBuffer<Vertex> vtx_buffer;
 
-[[vk::binding(1, 0)]]
+[[vk::binding(0, 1)]]
 StructuredBuffer<u32> idx_buffer;
 
-[[vk::binding(2, 0)]]
+[[vk::binding(0, 2)]]
 StructuredBuffer<PbrExtParam> params;
 
-[[vk::binding(3, 0)]]
+[[vk::binding(0, 3)]]
 StructuredBuffer<PunctualLight> lights;
 
-[[vk::binding(4, 0)]]
+[[vk::binding(0, 4)]]
 SamplerState samplers[];
 
-[[vk::binding(5, 0)]]
+[[vk::binding(0, 5)]]
 Texture2D textures[];
 
 struct VertexOutput
 {
-  f32x4 world_pos : WORLD_POS;
-  f32x2 uv : UV_COORD;
-  f32x4 position : SV_Position;
+  f32x4                                   position : SV_Position;
+  [[vk::location(0)]] nointerpolation u32 instance : INSTANCE;
+  [[vk::location(1)]] f32x4               world_pos : WORLD_POS;
+  [[vk::location(2)]] f32x2               uv : UV_COORD;
 };
 
 [[shader("vertex")]]
@@ -132,17 +133,19 @@ VertexOutput vs_main(u32 instance : SV_InstanceID, u32 vertex : SV_VertexID)
   var idx       = idx_buffer[vertex];
   var vtx       = vtx_buffer[p.first_vertex + idx];
   var world_pos = mul(p.transform, vtx.pos);
-  return VertexOutput(world_pos, vtx.uv, mul(world_to_view, world_pos));
+  return VertexOutput(mul(world_to_view, world_pos), instance, world_pos,
+                      vtx.uv);
 }
 
 static constexpr u32 NUM_OBJECT_LIGHTS = 4;
 
 [[shader("fragment")]]
-f32x4 fs_main(u32 instance : SV_InstanceID, f32x4 world_pos : WORLD_POS,
-              f32x2 uv : UV_COORD)
+f32x4 fs_main([[vk::location(0)]] u32   instance : INSTANCE,
+              [[vk::location(1)]] f32x4 world_pos : WORLD_POS,
+              [[vk::location(2)]] f32x2 uv : UV_COORD)
 {
   var p = params[instance];
-  var m = PbrMaterial::load(p, samplers[(uint) p.sampler], uv);
+  var m = PbrMaterial::load(p, samplers[p.sampler], uv);
 
   // convert from perceptual roughness to actual roughness
   m.roughness           = pow(m.roughness, 2);

--- a/ashura/shaders/rrect.slang
+++ b/ashura/shaders/rrect.slang
@@ -5,10 +5,10 @@
 #include "modules/sdf.slang"
 #include "modules/types.slang"
 
-static constexpr int TOP_LEFT     = 0;
-static constexpr int TOP_RIGHT    = 1;
-static constexpr int BOTTOM_LEFT  = 2;
-static constexpr int BOTTOM_RIGHT = 3;
+static const int TOP_LEFT     = 0;
+static const int TOP_RIGHT    = 1;
+static const int BOTTOM_LEFT  = 2;
+static const int BOTTOM_RIGHT = 3;
 
 struct RRectParam
 {
@@ -21,23 +21,23 @@ struct RRectParam
   f32               stroke;
   f32               thickness;
   f32               edge_smoothness;
-  u16               sampler;
-  u16               albedo;
+  u32               sampler;
+  u32               albedo;
 };
 
 [[vk::push_constant]]
-row_major f32x4x4 world_to_view;
+row_major ConstantBuffer<f32x4x4, Std430DataLayout> world_to_view;
 
 [[vk::binding(0, 0)]]
 StructuredBuffer<RRectParam> params;
 
-[[vk::binding(1, 0)]]
+[[vk::binding(0, 1)]]
 SamplerState samplers[];
 
-[[vk::binding(2, 0)]]
+[[vk::binding(0, 2)]]
 Texture2D textures[];
 
-static constexpr f32x2 VERTEX_BUFFER[] = {
+static const f32x2 VERTEX_BUFFER[] = {
   {-0.5, -0.5},
   {0.5,  -0.5},
   {0.5,  0.5 },
@@ -46,8 +46,9 @@ static constexpr f32x2 VERTEX_BUFFER[] = {
 
 struct VertexOutput
 {
-  f32x2 local_pos : REL_POSITION;
-  f32x4 pos : SV_Position;
+  f32x4                                   pos : SV_Position;
+  [[vk::location(0)]] nointerpolation u32 instance : INSTANCE;
+  [[vk::location(1)]] f32x2               local_pos : REL_POSITION;
 };
 
 [[shader("vertex")]] VertexOutput vs_main(u32 instance : SV_InstanceID,
@@ -56,11 +57,12 @@ struct VertexOutput
   var   p         = params[instance];
   f32x2 local_pos = VERTEX_BUFFER[vertex];
   f32x4 pos = mul(world_to_view, mul(p.transform, f32x4(local_pos, 0.0, 1.0)));
-  return VertexOutput(local_pos, pos);
+  return VertexOutput(pos, instance, local_pos);
 }
 
-[[shader("fragment")]] f32x4 fs_main(u32   instance : SV_InstanceID,
-                                     f32x2 local_pos : REL_POSITION) :
+[[shader("fragment")]] f32x4
+  fs_main([[vk::location(0)]] u32   instance : INSTANCE,
+          [[vk::location(1)]] f32x2 local_pos : REL_POSITION) :
   COLOR
 {
   var  p    = params[instance];
@@ -74,10 +76,10 @@ struct VertexOutput
   f32          dist        = rrect_sdf(pos, half_extent, radius);
   f32x2        uv          = local_pos + 0.5;
   f32x2        tex_uv      = lerp(p.uv.xy, p.uv.zw, uv);
-  SamplerState s = samplers[NonUniformResourceIndex((uint) p.sampler)];
-  f32x4 color    = textures[NonUniformResourceIndex((uint) p.albedo)].Sample(
-                  s, tex_uv * p.tiling) *
-                bilerp(p.tint, uv);
+  SamplerState s           = samplers[NonUniformResourceIndex(p.sampler)];
+  f32x4        color =
+    textures[NonUniformResourceIndex(p.albedo)].Sample(s, tex_uv * p.tiling) *
+    bilerp(p.tint, uv);
   f32 fill_alpha = 1 - smoothstep(0, p.edge_smoothness, dist);
   f32 stroke_alpha =
     1 - smoothstep(p.thickness, p.thickness + p.edge_smoothness,

--- a/compile_shaders.ps1
+++ b/compile_shaders.ps1
@@ -5,13 +5,16 @@ $SRC_DIR = "ashura/shaders"
 
 New-Item -ItemType Directory -Force -Path $OUT_DIR
 
+$FEATURES = "SPV_EXT_descriptor_indexing+SPV_KHR_non_semantic_info+spvImageQuery+spvImageGatherExtended+spvShaderNonUniformEXT+spvShaderNonUniform+SPV_GOOGLE_user_type+spvDerivativeControl+spvSparseResidency+spvMinLod+spvFragmentFullyCoveredEXT"
+$FLAGS = @("-profile", "spirv_1_3+$FEATURES", "-emit-spirv-directly", "-preserve-params" , "-matrix-layout-row-major" , "-fvk-use-gl-layout", "-fvk-use-entrypoint-name", "-O3")
+
 function compile_shader {
     param(
         $in
     )
 
-    slangc "$SRC_DIR/$in" -o "$OUT_DIR/$in.spv" -I "$INCLUDE_DIR"
-    slangc "$SRC_DIR/$in" -o "$OUT_DIR/$in.spv-asm" -I "$INCLUDE_DIR"
+    slangc -target spirv @FLAGS "$SRC_DIR/$in" -o "$OUT_DIR/$in.spv" -I "$INCLUDE_DIR"
+    slangc -target spirv-asm @FLAGS "$SRC_DIR/$in" -o "$OUT_DIR/$in.spv-asm" -I "$INCLUDE_DIR"
 }
 
 # [ ] make this part of cmake


### PR DESCRIPTION
This merge requests updates the spirv target to SPIRV-1.3 (Vulkan 1.1) and makes the SPIRV capability requirements explicit.
It updates the push constant location to a true push constant instead of the globalParams from slang.
It also removes the (u)int16 type from the shaders as it isn't supported by a number of our high-end target mobile platforms as of now, i.e. (Samsung Galaxy series). See: https://vulkan.gpuinfo.org/listdevicescoverage.php?extension=VK_KHR_16bit_storage&platform=all&option=not