### PR TITLE
Refactored String Type

### DIFF
--- a/ashura/engine/canvas.h
+++ b/ashura/engine/canvas.h
@@ -173,7 +173,7 @@ struct Canvas
 
   struct Pass
   {
-    Span<char const> label = {};
+    Str label = {};
 
     PassFn task{};
   };
@@ -327,7 +327,7 @@ struct Canvas
   Canvas & pass(Pass pass);
 
   template <typename Lambda>
-  Canvas & pass(Span<char const> label, Lambda task)
+  Canvas & pass(Str label, Lambda task)
   {
     // relocate lambda to heap
     Dyn<Lambda *> lambda =

--- a/ashura/engine/engine.cc
+++ b/ashura/engine/engine.cc
@@ -280,9 +280,8 @@ static void window_event_listener(Engine * engine, WindowEvent const & event)
     });
 }
 
-Dyn<Engine *> Engine::create(AllocatorRef     allocator,
-                             Span<char const> config_path,
-                             Span<char const> working_dir)
+Dyn<Engine *> Engine::create(AllocatorRef allocator, Str config_path,
+                             Str working_dir)
 {
   Dyn<Logger *> logger =
     dyn<Logger>(inplace, default_allocator, span<LogSink *>({&stdio_sink}))

--- a/ashura/engine/engine.h
+++ b/ashura/engine/engine.h
@@ -96,9 +96,8 @@ struct Engine
 
   nanoseconds min_frame_interval;
 
-  static Dyn<Engine *> create(AllocatorRef     allocator,
-                              Span<char const> config_path,
-                              Span<char const> working_dir);
+  static Dyn<Engine *> create(AllocatorRef allocator, Str config_path,
+                              Str working_dir);
 
   Engine(AllocatorRef allocator, Dyn<Logger *> logger,
          Dyn<Scheduler *> scheduler, FileSystem file_sys,

--- a/ashura/engine/font.h
+++ b/ashura/engine/font.h
@@ -40,7 +40,7 @@ enum class FontLoadErr : u32
   UnsupportedFormat = 5
 };
 
-constexpr Span<char const> to_str(FontLoadErr err)
+constexpr Str to_str(FontLoadErr err)
 {
   switch (err)
   {
@@ -141,11 +141,11 @@ struct GpuFontAtlas
 struct FontInfo
 {
   FontId                        id                = FontId::Invalid;
-  Span<char const>              label             = {};
+  Str                           label             = {};
   bool                          has_color         = false;
-  Span<char const>              postscript_name   = {};
-  Span<char const>              family_name       = {};
-  Span<char const>              style_name        = {};
+  Str                           postscript_name   = {};
+  Str                           family_name       = {};
+  Str                           style_name        = {};
   Span<GlyphMetrics const>      glyphs            = {};
   u32                           replacement_glyph = 0;
   u32                           space_glyph       = 0;

--- a/ashura/engine/font_system_impl.h
+++ b/ashura/engine/font_system_impl.h
@@ -29,8 +29,8 @@ struct FontSystemImpl : FontSystem
 
   virtual void shutdown() override;
 
-  Result<Dyn<Font *>, FontLoadErr>
-    decode_(Span<char const> label, Span<u8 const> encoded, u32 face = 0);
+  Result<Dyn<Font *>, FontLoadErr> decode_(Str label, Span<u8 const> encoded,
+                                           u32 face = 0);
 
   virtual Result<> rasterize(Font & font, u32 font_height) override;
 
@@ -44,12 +44,12 @@ struct FontSystemImpl : FontSystem
                      u32 face = 0) override;
 
   virtual Future<Result<FontId, FontLoadErr>>
-    load_from_path(Vec<char> label, Span<char const> path, u32 font_height,
+    load_from_path(Vec<char> label, Str path, u32 font_height,
                    u32 face = 0) override;
 
   virtual FontInfo get(FontId id) override;
 
-  virtual FontInfo get(Span<char const> label) override;
+  virtual FontInfo get(Str label) override;
 
   virtual void unload(FontId id) override;
 };

--- a/ashura/engine/gpu_system.cc
+++ b/ashura/engine/gpu_system.cc
@@ -192,8 +192,8 @@ void GpuQueries::begin_frame(gpu::Device & dev, gpu::CommandEncoder & enc)
 
   for (auto const [i, label] : enumerate<u32>(statistics_labels_))
   {
-    gpu::PipelineStatistics const &            stat      = cpu_statistics_[i];
-    Tuple<Span<char const>, TraceRecord> const records[] = {
+    gpu::PipelineStatistics const & stat      = cpu_statistics_[i];
+    Tuple<Str, TraceRecord> const   records[] = {
       {"gpu.input_assembly_vertices"_str,
        {.label = label, .i = (i64) stat.input_assembly_vertices}    },
       {"gpu.vertex_shader_invocations"_str,
@@ -218,8 +218,7 @@ void GpuQueries::begin_frame(gpu::Device & dev, gpu::CommandEncoder & enc)
   statistics_labels_.clear();
 }
 
-Option<u32> GpuQueries::begin_timespan(gpu::CommandEncoder & enc,
-                                       Span<char const>      label)
+Option<u32> GpuQueries::begin_timespan(gpu::CommandEncoder & enc, Str label)
 {
   u32 const id = timespan_labels_.size32();
 
@@ -241,8 +240,7 @@ void GpuQueries::end_timespan(gpu::CommandEncoder & enc, u32 id)
                       id * 2 + 1);
 }
 
-Option<u32> GpuQueries::begin_statistics(gpu::CommandEncoder & enc,
-                                         Span<char const>      label)
+Option<u32> GpuQueries::begin_statistics(gpu::CommandEncoder & enc, Str label)
 {
   u32 const id = statistics_labels_.size32();
 
@@ -482,68 +480,67 @@ GpuSystem GpuSystem::create(AllocatorRef allocator, gpu::Device & device,
                 std::move(queries)};
 
   {
-    static constexpr Tuple<Span<char const>, TextureId, gpu::ComponentMapping>
-      mappings[] = {
-        {"Default White Texture"_str,
-         TextureId::White,
-         {.r = gpu::ComponentSwizzle::One,
-          .g = gpu::ComponentSwizzle::One,
-          .b = gpu::ComponentSwizzle::One,
-          .a = gpu::ComponentSwizzle::One} },
-        {"Default Black Texture"_str,
-         TextureId::Black,
-         {.r = gpu::ComponentSwizzle::Zero,
-          .g = gpu::ComponentSwizzle::Zero,
-          .b = gpu::ComponentSwizzle::Zero,
-          .a = gpu::ComponentSwizzle::One} },
-        {"Default Transparent Texture"_str,
-         TextureId::Transparent,
-         {.r = gpu::ComponentSwizzle::Zero,
-          .g = gpu::ComponentSwizzle::Zero,
-          .b = gpu::ComponentSwizzle::Zero,
-          .a = gpu::ComponentSwizzle::Zero}},
-        {"Default Alpha Texture"_str,
-         TextureId::Alpha,
-         {.r = gpu::ComponentSwizzle::Zero,
-          .g = gpu::ComponentSwizzle::Zero,
-          .b = gpu::ComponentSwizzle::Zero,
-          .a = gpu::ComponentSwizzle::One} },
-        {"Default Red Texture"_str,
-         TextureId::Red,
-         {.r = gpu::ComponentSwizzle::One,
-          .g = gpu::ComponentSwizzle::Zero,
-          .b = gpu::ComponentSwizzle::Zero,
-          .a = gpu::ComponentSwizzle::One} },
-        {"Default Green Texture"_str,
-         TextureId::Green,
-         {.r = gpu::ComponentSwizzle::Zero,
-          .g = gpu::ComponentSwizzle::One,
-          .b = gpu::ComponentSwizzle::Zero,
-          .a = gpu::ComponentSwizzle::One} },
-        {"Default Blue Texture"_str,
-         TextureId::Blue,
-         {.r = gpu::ComponentSwizzle::Zero,
-          .g = gpu::ComponentSwizzle::Zero,
-          .b = gpu::ComponentSwizzle::One,
-          .a = gpu::ComponentSwizzle::One} },
-        {"Default Magenta Texture"_str,
-         TextureId::Magenta,
-         {.r = gpu::ComponentSwizzle::One,
-          .g = gpu::ComponentSwizzle::Zero,
-          .b = gpu::ComponentSwizzle::One,
-          .a = gpu::ComponentSwizzle::One} },
-        {"Default Cyan Texture"_str,
-         TextureId::Cyan,
-         {.r = gpu::ComponentSwizzle::Zero,
-          .g = gpu::ComponentSwizzle::One,
-          .b = gpu::ComponentSwizzle::One,
-          .a = gpu::ComponentSwizzle::One} },
-        {"Default Yellow Texture"_str,
-         TextureId::Yellow,
-         {.r = gpu::ComponentSwizzle::One,
-          .g = gpu::ComponentSwizzle::One,
-          .b = gpu::ComponentSwizzle::Zero,
-          .a = gpu::ComponentSwizzle::One} }
+    static constexpr Tuple<Str, TextureId, gpu::ComponentMapping> mappings[] = {
+      {"Default White Texture"_str,
+       TextureId::White,
+       {.r = gpu::ComponentSwizzle::One,
+        .g = gpu::ComponentSwizzle::One,
+        .b = gpu::ComponentSwizzle::One,
+        .a = gpu::ComponentSwizzle::One} },
+      {"Default Black Texture"_str,
+       TextureId::Black,
+       {.r = gpu::ComponentSwizzle::Zero,
+        .g = gpu::ComponentSwizzle::Zero,
+        .b = gpu::ComponentSwizzle::Zero,
+        .a = gpu::ComponentSwizzle::One} },
+      {"Default Transparent Texture"_str,
+       TextureId::Transparent,
+       {.r = gpu::ComponentSwizzle::Zero,
+        .g = gpu::ComponentSwizzle::Zero,
+        .b = gpu::ComponentSwizzle::Zero,
+        .a = gpu::ComponentSwizzle::Zero}},
+      {"Default Alpha Texture"_str,
+       TextureId::Alpha,
+       {.r = gpu::ComponentSwizzle::Zero,
+        .g = gpu::ComponentSwizzle::Zero,
+        .b = gpu::ComponentSwizzle::Zero,
+        .a = gpu::ComponentSwizzle::One} },
+      {"Default Red Texture"_str,
+       TextureId::Red,
+       {.r = gpu::ComponentSwizzle::One,
+        .g = gpu::ComponentSwizzle::Zero,
+        .b = gpu::ComponentSwizzle::Zero,
+        .a = gpu::ComponentSwizzle::One} },
+      {"Default Green Texture"_str,
+       TextureId::Green,
+       {.r = gpu::ComponentSwizzle::Zero,
+        .g = gpu::ComponentSwizzle::One,
+        .b = gpu::ComponentSwizzle::Zero,
+        .a = gpu::ComponentSwizzle::One} },
+      {"Default Blue Texture"_str,
+       TextureId::Blue,
+       {.r = gpu::ComponentSwizzle::Zero,
+        .g = gpu::ComponentSwizzle::Zero,
+        .b = gpu::ComponentSwizzle::One,
+        .a = gpu::ComponentSwizzle::One} },
+      {"Default Magenta Texture"_str,
+       TextureId::Magenta,
+       {.r = gpu::ComponentSwizzle::One,
+        .g = gpu::ComponentSwizzle::Zero,
+        .b = gpu::ComponentSwizzle::One,
+        .a = gpu::ComponentSwizzle::One} },
+      {"Default Cyan Texture"_str,
+       TextureId::Cyan,
+       {.r = gpu::ComponentSwizzle::Zero,
+        .g = gpu::ComponentSwizzle::One,
+        .b = gpu::ComponentSwizzle::One,
+        .a = gpu::ComponentSwizzle::One} },
+      {"Default Yellow Texture"_str,
+       TextureId::Yellow,
+       {.r = gpu::ComponentSwizzle::One,
+        .g = gpu::ComponentSwizzle::One,
+        .b = gpu::ComponentSwizzle::Zero,
+        .a = gpu::ComponentSwizzle::One} }
     };
 
     static_assert(size(mappings) == NUM_DEFAULT_TEXTURES);
@@ -1134,7 +1131,7 @@ void GpuSystem::submit_frame(gpu::Swapchain swapchain)
   device_->submit_frame(swapchain).unwrap();
 }
 
-Option<u32> GpuSystem::begin_timespan(Span<char const> label)
+Option<u32> GpuSystem::begin_timespan(Str label)
 {
   return queries_[ring_index()].begin_timespan(encoder(), label);
 }
@@ -1144,7 +1141,7 @@ void GpuSystem::end_timespan(u32 id)
   queries_[ring_index()].end_timespan(encoder(), id);
 }
 
-Option<u32> GpuSystem::begin_statistics(Span<char const> label)
+Option<u32> GpuSystem::begin_statistics(Str label)
 {
   return queries_[ring_index()].begin_statistics(encoder(), label);
 }

--- a/ashura/engine/gpu_system.h
+++ b/ashura/engine/gpu_system.h
@@ -160,7 +160,7 @@ typedef Map<gpu::SamplerInfo, Sampler, SamplerHasher, SamplerEq, u32>
 
 struct StagingBuffer
 {
-  Span<char const> label = "Staging Buffer"_str;
+  Str label = "Staging Buffer"_str;
 
   gpu::Buffer buffer = nullptr;
 
@@ -305,9 +305,9 @@ struct GpuQueries
 
   Vec<gpu::PipelineStatistics> cpu_statistics_;
 
-  Vec<Span<char const>> timespan_labels_;
+  Vec<Str> timespan_labels_;
 
-  Vec<Span<char const>> statistics_labels_;
+  Vec<Str> statistics_labels_;
 
   static GpuQueries create(AllocatorRef allocator, gpu::Device & dev,
                            f32 time_period, u32 num_timespans,
@@ -338,12 +338,11 @@ struct GpuQueries
 
   void begin_frame(gpu::Device & dev, gpu::CommandEncoder & enc);
 
-  Option<u32> begin_timespan(gpu::CommandEncoder & enc, Span<char const> label);
+  Option<u32> begin_timespan(gpu::CommandEncoder & enc, Str label);
 
   void end_timespan(gpu::CommandEncoder & enc, u32 id);
 
-  Option<u32> begin_statistics(gpu::CommandEncoder & enc,
-                               Span<char const>      label);
+  Option<u32> begin_statistics(gpu::CommandEncoder & enc, Str label);
 
   void end_statistics(gpu::CommandEncoder & enc, u32 id);
 };
@@ -532,18 +531,18 @@ struct GpuSystem
 
   void submit_frame(gpu::Swapchain swapchain);
 
-  Option<u32> begin_timespan(Span<char const> label);
+  Option<u32> begin_timespan(Str label);
 
   void end_timespan(u32 id);
 
-  Option<u32> begin_statistics(Span<char const> label);
+  Option<u32> begin_statistics(Str label);
 
   void end_statistics(u32 id);
 };
 
 struct SSBO
 {
-  Span<char const> label = "SSBO"_str;
+  Str label = "SSBO"_str;
 
   gpu::Buffer buffer = nullptr;
 

--- a/ashura/engine/passes.h
+++ b/ashura/engine/passes.h
@@ -20,10 +20,10 @@ struct FramebufferResult
 /// used by renderers.
 struct Pass
 {
-  virtual Span<char const> label()   = 0;
-  virtual void             acquire() = 0;
-  virtual void             release() = 0;
-  virtual ~Pass()                    = default;
+  virtual Str  label()   = 0;
+  virtual void acquire() = 0;
+  virtual void release() = 0;
+  virtual ~Pass()        = default;
 };
 
 struct BloomPassParams
@@ -40,7 +40,7 @@ struct BloomPass : Pass
 
   virtual ~BloomPass() override = default;
 
-  virtual Span<char const> label() override
+  virtual Str label() override
   {
     return "Bloom"_str;
   }
@@ -76,7 +76,7 @@ struct BlurPass : Pass
 
   virtual ~BlurPass() override = default;
 
-  virtual Span<char const> label() override
+  virtual Str label() override
   {
     return "Blur"_str;
   }
@@ -126,7 +126,7 @@ struct NgonPass : Pass
 
   virtual ~NgonPass() override = default;
 
-  virtual Span<char const> label() override
+  virtual Str label() override
   {
     return "Ngon"_str;
   }
@@ -204,7 +204,7 @@ struct PBRPass : Pass
 
   virtual ~PBRPass() override = default;
 
-  virtual Span<char const> label() override
+  virtual Str label() override
   {
     return "PBR"_str;
   }
@@ -248,7 +248,7 @@ struct RRectPass : Pass
 {
   gpu::GraphicsPipeline pipeline = nullptr;
 
-  virtual Span<char const> label() override
+  virtual Str label() override
   {
     return "RRect"_str;
   }

--- a/ashura/engine/render_text.cc
+++ b/ashura/engine/render_text.cc
@@ -154,7 +154,7 @@ RenderText & RenderText::direction(TextDirection direction)
   return *this;
 }
 
-RenderText & RenderText::language(Span<char const> language)
+RenderText & RenderText::language(Str language)
 {
   if (range_eq(language_, language))
   {
@@ -176,12 +176,12 @@ RenderText & RenderText::alignment(f32 alignment)
   return *this;
 }
 
-Span<c32 const> RenderText::get_text() const
+Str32 RenderText::get_text() const
 {
   return text_;
 }
 
-RenderText & RenderText::text(Span<c32 const> utf32, TextStyle const & style,
+RenderText & RenderText::text(Str32 utf32, TextStyle const & style,
                               FontStyle const & font)
 {
   text(utf32);
@@ -190,7 +190,7 @@ RenderText & RenderText::text(Span<c32 const> utf32, TextStyle const & style,
   return *this;
 }
 
-RenderText & RenderText::text(Span<c32 const> utf32)
+RenderText & RenderText::text(Str32 utf32)
 {
   text_.clear();
   text_.extend(utf32).unwrap();
@@ -198,7 +198,7 @@ RenderText & RenderText::text(Span<c32 const> utf32)
   return *this;
 }
 
-RenderText & RenderText::text(Span<c8 const> utf8, TextStyle const & style,
+RenderText & RenderText::text(Str8 utf8, TextStyle const & style,
                               FontStyle const & font)
 {
   run(style, font);
@@ -207,7 +207,7 @@ RenderText & RenderText::text(Span<c8 const> utf8, TextStyle const & style,
   return *this;
 }
 
-RenderText & RenderText::text(Span<c8 const> utf8)
+RenderText & RenderText::text(Str8 utf8)
 {
   text_.clear();
   utf8_decode(utf8, text_).unwrap();

--- a/ashura/engine/render_text.h
+++ b/ashura/engine/render_text.h
@@ -18,19 +18,19 @@ namespace ash
 /// @param runs  Run-End encoded sequences of the runs
 struct RenderText
 {
-  hash64           hash_;
-  bool             use_kerning_   : 1;
-  bool             use_ligatures_ : 1;
-  TextDirection    direction_     : 2;
-  f32              alignment_;
-  f32              font_scale_;
-  Vec<c32>         text_;
-  Vec<u32>         runs_;
-  Vec<TextStyle>   styles_;
-  Vec<FontStyle>   fonts_;
-  Span<char const> language_;
-  TextLayout       layout_;
-  TextHighlight    highlight_;
+  hash64         hash_;
+  bool           use_kerning_   : 1;
+  bool           use_ligatures_ : 1;
+  TextDirection  direction_     : 2;
+  f32            alignment_;
+  f32            font_scale_;
+  Vec<c32>       text_;
+  Vec<u32>       runs_;
+  Vec<TextStyle> styles_;
+  Vec<FontStyle> fonts_;
+  Str            language_;
+  TextLayout     layout_;
+  TextHighlight  highlight_;
 
   RenderText(AllocatorRef allocator) :
     hash_{0},
@@ -76,21 +76,20 @@ struct RenderText
 
   RenderText & direction(TextDirection direction);
 
-  RenderText & language(Span<char const> language);
+  RenderText & language(Str language);
 
   RenderText & alignment(f32 alignment);
 
-  Span<c32 const> get_text() const;
+  Str32 get_text() const;
 
-  RenderText & text(Span<c32 const> utf32, TextStyle const & style,
+  RenderText & text(Str32 utf32, TextStyle const & style,
                     FontStyle const & font);
 
-  RenderText & text(Span<c32 const> utf32);
+  RenderText & text(Str32 utf32);
 
-  RenderText & text(Span<c8 const> utf8, TextStyle const & style,
-                    FontStyle const & font);
+  RenderText & text(Str8 utf8, TextStyle const & style, FontStyle const & font);
 
-  RenderText & text(Span<c8 const> utf8);
+  RenderText & text(Str8 utf8);
 
   TextBlock block() const;
 

--- a/ashura/engine/renderer.h
+++ b/ashura/engine/renderer.h
@@ -45,7 +45,6 @@ struct PassContext
   void add_pass(Dyn<Pass *> pass);
 };
 
-// [ ] REMOVE TASK QUEUE
 struct FrameGraph
 {
   typedef Dyn<Fn<void(FrameGraph & graph, gpu::CommandEncoder & enc,
@@ -54,8 +53,8 @@ struct FrameGraph
 
   struct Pass
   {
-    Span<char const> label;
-    PassFn           pass;
+    Str    label;
+    PassFn pass;
   };
 
   struct FrameData
@@ -99,7 +98,7 @@ struct FrameGraph
   void add_pass(Pass pass);
 
   template <typename Lambda>
-  void add_pass(Span<char const> label, Lambda task)
+  void add_pass(Str label, Lambda task)
   {
     // relocate lambda to heap
     Dyn<Lambda *> lambda = dyn(arena_, static_cast<Lambda &&>(task)).unwrap();

--- a/ashura/engine/shader.cc
+++ b/ashura/engine/shader.cc
@@ -150,7 +150,7 @@ struct Includer : glslang::TShader::Includer
 
     return info.on_load(cstr_span(header_name))
       .match(
-        [&](Span<char const> header_data) -> IncludeResult * {
+        [&](Str header_data) -> IncludeResult * {
           IncludeResult * result;
           if (!allocator->nalloc(1, result))
           {

--- a/ashura/engine/shader.h
+++ b/ashura/engine/shader.h
@@ -31,16 +31,15 @@ struct ShaderCompileInfo
 {
   ShaderType type = ShaderType::Compute;
 
-  Span<char const> path{};
+  Str path{};
 
-  Span<char const> preamble{};
+  Str preamble{};
 
-  Fn<void(LogLevel, Span<char const>)> on_log = noop;
+  Fn<void(LogLevel, Str)> on_log = noop;
 
-  Fn<Option<Span<char const>>(Span<char const>)> on_load =
-    [](Span<char const>) -> Option<Span<char const>> { return none; };
+  Fn<Option<Str>(Str)> on_load = [](Str) -> Option<Str> { return none; };
 
-  Fn<void(Span<char const>)> on_drop = noop;
+  Fn<void(Str)> on_drop = noop;
 };
 
 Result<Void, ShaderLoadErr> compile_shader(ShaderCompileInfo const & info,

--- a/ashura/engine/systems.cc
+++ b/ashura/engine/systems.cc
@@ -6,7 +6,7 @@
 namespace ash
 {
 
-Future<Result<Vec<u8>, IoErr>> FileSystem::load_file(Span<char const> path)
+Future<Result<Vec<u8>, IoErr>> FileSystem::load_file(Str path)
 {
   Vec<char> path_copy{allocator_};
   path_copy.extend(path).unwrap();
@@ -151,8 +151,6 @@ ImageInfo ImageSystem::upload_(Vec<char> label, gpu::ImageInfo const & info,
   ImageInfo image =
     create_image_(std::move(label), resolved_info, resolved_view_infos);
 
-  // [ ] move upload queue to Framegraph
-
   sys->gpu.upload_.queue(
     bgra, [image = image.image, info](gpu::CommandEncoder & enc,
                                       gpu::Buffer buffer, Slice64 slice) {
@@ -183,7 +181,7 @@ Result<ImageInfo, ImageLoadErr>
 }
 
 Future<Result<ImageInfo, ImageLoadErr>>
-  ImageSystem::load_from_path(Vec<char> label, Span<char const> path)
+  ImageSystem::load_from_path(Vec<char> label, Str path)
 {
   Future fut = future<Result<ImageInfo, ImageLoadErr>>(allocator_).unwrap();
   Future load_fut = sys->file.load_file(path);
@@ -255,7 +253,7 @@ Future<Result<ImageInfo, ImageLoadErr>>
   return fut;
 }
 
-ImageInfo ImageSystem::get(Span<char const> label)
+ImageInfo ImageSystem::get(Str label)
 {
   for (auto & image : images_.dense.v0)
   {
@@ -315,7 +313,7 @@ Result<ShaderInfo, ShaderLoadErr>
 }
 
 Future<Result<ShaderInfo, ShaderLoadErr>>
-  ShaderSystem::load_from_path(Vec<char> label, Span<char const> path)
+  ShaderSystem::load_from_path(Vec<char> label, Str path)
 {
   Future load_fut = sys->file.load_file(path);
   Future fut = future<Result<ShaderInfo, ShaderLoadErr>>(allocator_).unwrap();
@@ -355,7 +353,7 @@ ShaderInfo ShaderSystem::get(ShaderId id)
   return shaders_[(usize) id].v0.view();
 }
 
-ShaderInfo ShaderSystem::get(Span<char const> label)
+ShaderInfo ShaderSystem::get(Str label)
 {
   for (auto [shader] : shaders_)
   {

--- a/ashura/engine/systems.h
+++ b/ashura/engine/systems.h
@@ -16,7 +16,7 @@ struct ImageInfo
 {
   ImageId id = ImageId::Invalid;
 
-  Span<char const> label{};
+  Str label{};
 
   Span<TextureId const> textures{};
 
@@ -61,7 +61,7 @@ struct ShaderInfo
 {
   ShaderId id{};
 
-  Span<char const> label{};
+  Str label{};
 
   gpu::Shader shader = nullptr;
 };
@@ -96,7 +96,7 @@ struct FileSystem
 
   void shutdown();
 
-  Future<Result<Vec<u8>, IoErr>> load_file(Span<char const> path);
+  Future<Result<Vec<u8>, IoErr>> load_file(Str path);
 };
 
 struct ImageSystem
@@ -131,10 +131,10 @@ struct ImageSystem
                      Span<gpu::ImageViewInfo const> view_infos,
                      Span<u8 const>                 channels);
 
-  Future<Result<ImageInfo, ImageLoadErr>> load_from_path(Vec<char>        label,
-                                                         Span<char const> path);
+  Future<Result<ImageInfo, ImageLoadErr>> load_from_path(Vec<char> label,
+                                                         Str       path);
 
-  ImageInfo get(Span<char const> label);
+  ImageInfo get(Str label);
 
   ImageInfo get(ImageId id);
 
@@ -164,13 +164,14 @@ struct FontSystem
     load_from_memory(Vec<char> label, Vec<u8> encoded, u32 font_height,
                      u32 face = 0) = 0;
 
-  virtual Future<Result<FontId, FontLoadErr>>
-    load_from_path(Vec<char> label, Span<char const> path, u32 font_height,
-                   u32 face = 0) = 0;
+  virtual Future<Result<FontId, FontLoadErr>> load_from_path(Vec<char> label,
+                                                             Str       path,
+                                                             u32 font_height,
+                                                             u32 face = 0) = 0;
 
   virtual FontInfo get(FontId id) = 0;
 
-  virtual FontInfo get(Span<char const> label) = 0;
+  virtual FontInfo get(Str label) = 0;
 
   virtual void unload(FontId id) = 0;
 };
@@ -197,12 +198,12 @@ struct ShaderSystem
   Result<ShaderInfo, ShaderLoadErr> load_from_memory(Vec<char>       label,
                                                      Span<u32 const> spirv);
 
-  Future<Result<ShaderInfo, ShaderLoadErr>>
-    load_from_path(Vec<char> label, Span<char const> path);
+  Future<Result<ShaderInfo, ShaderLoadErr>> load_from_path(Vec<char> label,
+                                                           Str       path);
 
   ShaderInfo get(ShaderId id);
 
-  ShaderInfo get(Span<char const> label);
+  ShaderInfo get(Str label);
 
   void unload(ShaderId);
 };

--- a/ashura/engine/text.h
+++ b/ashura/engine/text.h
@@ -279,13 +279,13 @@ struct TextStyle
 /// @param use_ligatures use standard and contextual font ligature substitution
 struct TextBlock
 {
-  Span<c32 const>       text          = {};
+  Str32                 text          = {};
   hash64                hash          = 0;
   Span<u32 const>       runs          = {};
   Span<FontStyle const> fonts         = {};
   f32                   font_scale    = 1;
   TextDirection         direction     = TextDirection::LeftToRight;
-  Span<char const>      language      = {};
+  Str                   language      = {};
   bool                  use_kerning   = true;
   bool                  use_ligatures = true;
 };

--- a/ashura/engine/text_compositor.h
+++ b/ashura/engine/text_compositor.h
@@ -161,7 +161,7 @@ struct TextCompositor
   /// @param index destination index, needs to be clamped to the size of the
   /// destination container.
   /// @param text text to be inserted
-  typedef Fn<void(usize, Span<c32 const>)> Insert;
+  typedef Fn<void(usize, Str32)> Insert;
 
   /// @brief Text erase callback.
   /// @param index index to be erased from, needs to be clamped to the size of
@@ -183,13 +183,13 @@ struct TextCompositor
   usize               latest_record_  = 0;
   usize               current_record_ = 0;
   u32                 tab_width_;
-  Span<c32 const>     word_symbols_;
-  Span<c32 const>     line_symbols_;
+  Str32               word_symbols_;
+  Str32               line_symbols_;
 
   TextCompositor(AllocatorRef allocator, u32 tab_width = 2,
                  usize buffer_size = 4'096, usize records_size = 1'024,
-                 Span<c32 const> word_symbols = DEFAULT_WORD_SYMBOLS,
-                 Span<c32 const> line_symbols = DEFAULT_LINE_SYMBOLS) :
+                 Str32 word_symbols = DEFAULT_WORD_SYMBOLS,
+                 Str32 line_symbols = DEFAULT_LINE_SYMBOLS) :
     allocator_{allocator},
     buffer_{allocator},
     records_{allocator},
@@ -216,7 +216,7 @@ struct TextCompositor
 
   void pop_records(usize num);
 
-  void append_record(bool is_insert, usize text_pos, Span<c32 const> segment);
+  void append_record(bool is_insert, usize text_pos, Str32 segment);
 
   void undo(Insert insert, Erase erase);
 
@@ -224,11 +224,11 @@ struct TextCompositor
 
   void unselect();
 
-  void delete_selection(Span<c32 const> text, Erase erase);
+  void delete_selection(Str32 text, Erase erase);
 
   /// @param input text from IME to insert
   Slice command(RenderText const & text, TextCommand cmd, Insert insert,
-                Erase erase, Span<c32 const> input, ClipBoard & clipboard,
+                Erase erase, Str32 input, ClipBoard & clipboard,
                 u32 lines_per_page, CRect const & region, Vec2 pos, f32 zoom);
 };
 

--- a/ashura/engine/views.cc
+++ b/ashura/engine/views.cc
@@ -327,7 +327,7 @@ i32 Stack::z_index(i32 allocated, Span<i32> indices)
   return allocated;
 }
 
-Text::Text(Span<c32 const> t, TextStyle const & style, FontStyle const & font,
+Text::Text(Str32 t, TextStyle const & style, FontStyle const & font,
            AllocatorRef allocator) :
   text_{allocator},
   compositor_{allocator}
@@ -335,7 +335,7 @@ Text::Text(Span<c32 const> t, TextStyle const & style, FontStyle const & font,
   text(t).run(style, font);
 }
 
-Text::Text(Span<c8 const> t, TextStyle const & style, FontStyle const & font,
+Text::Text(Str8 t, TextStyle const & style, FontStyle const & font,
            AllocatorRef allocator) :
   text_{allocator},
   compositor_{allocator}
@@ -362,19 +362,19 @@ Text & Text::run(TextStyle const & style, FontStyle const & font, u32 first,
   return *this;
 }
 
-Text & Text::text(Span<c32 const> t)
+Text & Text::text(Str32 t)
 {
   text_.text(t);
   return *this;
 }
 
-Text & Text::text(Span<c8 const> t)
+Text & Text::text(Str8 t)
 {
   text_.text(t);
   return *this;
 }
 
-Span<c32 const> Text::text()
+Str32 Text::text()
 {
   return text_.get_text();
 }
@@ -421,7 +421,7 @@ Cursor Text::cursor(CRect const &, f32, Vec2)
   return state.copyable ? Cursor::Text : Cursor::Default;
 }
 
-Input::Input(Span<c32 const> s, TextStyle const & style, FontStyle const & font,
+Input::Input(Str32 s, TextStyle const & style, FontStyle const & font,
              AllocatorRef allocator) :
   content_{allocator},
   stub_{allocator},
@@ -430,7 +430,7 @@ Input::Input(Span<c32 const> s, TextStyle const & style, FontStyle const & font,
   content(U""_str).content_run(style, font).stub(s).stub_run(style, font);
 }
 
-Input::Input(Span<c8 const> s, TextStyle const & style, FontStyle const & font,
+Input::Input(Str8 s, TextStyle const & style, FontStyle const & font,
              AllocatorRef allocator) :
   content_{allocator},
   stub_{allocator},
@@ -499,13 +499,13 @@ Input & Input::on_focus_out(Fn<void()> f)
   return *this;
 }
 
-Input & Input::content(Span<c8 const> t)
+Input & Input::content(Str8 t)
 {
   content_.text(t);
   return *this;
 }
 
-Input & Input::content(Span<c32 const> t)
+Input & Input::content(Str32 t)
 {
   content_.text(t);
   return *this;
@@ -518,13 +518,13 @@ Input & Input::content_run(TextStyle const & style, FontStyle const & font,
   return *this;
 }
 
-Input & Input::stub(Span<c8 const> t)
+Input & Input::stub(Str8 t)
 {
   stub_.text(t);
   return *this;
 }
 
-Input & Input::stub(Span<c32 const> t)
+Input & Input::stub(Str32 t)
 {
   stub_.text(t);
   return *this;
@@ -669,7 +669,7 @@ ViewState Input::tick(ViewContext const & ctx, CRect const & region, f32 zoom,
     this->content_.flush_text();
   };
 
-  auto insert = [&](usize pos, Span<c32 const> t) {
+  auto insert = [&](usize pos, Str32 t) {
     this->content_.text_.insert_span(pos, t).unwrap();
     edited |= t.is_empty();
     this->content_.flush_text();
@@ -869,13 +869,13 @@ Cursor Button::cursor(CRect const &, f32, Vec2)
   return state.disabled ? Cursor::Default : Cursor::Pointer;
 }
 
-TextButton::TextButton(Span<c32 const> text, TextStyle const & style,
+TextButton::TextButton(Str32 text, TextStyle const & style,
                        FontStyle const & font, AllocatorRef allocator) :
   text_{text, style, font, allocator}
 {
 }
 
-TextButton::TextButton(Span<c8 const> text, TextStyle const & style,
+TextButton::TextButton(Str8 text, TextStyle const & style,
                        FontStyle const & font, AllocatorRef allocator) :
   text_{text, style, font, allocator}
 {
@@ -894,13 +894,13 @@ TextButton & TextButton::run(TextStyle const & style, FontStyle const & font,
   return *this;
 }
 
-TextButton & TextButton::text(Span<c32 const> t)
+TextButton & TextButton::text(Str32 t)
 {
   text_.text(t);
   return *this;
 }
 
-TextButton & TextButton::text(Span<c8 const> t)
+TextButton & TextButton::text(Str8 t)
 {
   text_.text(t);
   return *this;
@@ -996,14 +996,14 @@ ViewState TextButton::tick(ViewContext const & ctx, CRect const & region,
   return state;
 }
 
-Icon::Icon(Span<c32 const> text, TextStyle const & style,
-           FontStyle const & font, AllocatorRef allocator) :
+Icon::Icon(Str32 text, TextStyle const & style, FontStyle const & font,
+           AllocatorRef allocator) :
   text_{allocator}
 {
   text_.text(text).run(style, font);
 }
 
-Icon::Icon(Span<c8 const> text, TextStyle const & style, FontStyle const & font,
+Icon::Icon(Str8 text, TextStyle const & style, FontStyle const & font,
            AllocatorRef allocator) :
   text_{allocator}
 {
@@ -1016,15 +1016,13 @@ Icon & Icon::hide(bool hide)
   return *this;
 }
 
-Icon & Icon::icon(Span<c8 const> text, TextStyle const & style,
-                  FontStyle const & font)
+Icon & Icon::icon(Str8 text, TextStyle const & style, FontStyle const & font)
 {
   text_.text(text).run(style, font);
   return *this;
 }
 
-Icon & Icon::icon(Span<c32 const> text, TextStyle const & style,
-                  FontStyle const & font)
+Icon & Icon::icon(Str32 text, TextStyle const & style, FontStyle const & font)
 {
   text_.text(text).run(style, font);
   return *this;
@@ -1048,14 +1046,14 @@ void Icon::render(Canvas & canvas, CRect const & region, f32 zoom,
   text_.render(canvas, region, clip.centered(), zoom);
 }
 
-CheckBox::CheckBox(Span<c32 const> text, TextStyle const & style,
-                   FontStyle const & font, AllocatorRef allocator) :
+CheckBox::CheckBox(Str32 text, TextStyle const & style, FontStyle const & font,
+                   AllocatorRef allocator) :
   icon_{text, style, font, allocator}
 {
 }
 
-CheckBox::CheckBox(Span<c8 const> text, TextStyle const & style,
-                   FontStyle const & font, AllocatorRef allocator) :
+CheckBox::CheckBox(Str8 text, TextStyle const & style, FontStyle const & font,
+                   AllocatorRef allocator) :
   icon_{text, style, font, allocator}
 {
 }
@@ -1617,7 +1615,7 @@ Cursor Radio::cursor(CRect const &, f32, Vec2)
   return Cursor::Pointer;
 }
 
-void ScalarDragBox::scalar_parse(Span<c32 const> text, ScalarInfo const & spec,
+void ScalarDragBox::scalar_parse(Str32 text, ScalarInfo const & spec,
                                  Scalar & scalar)
 {
   if (text.is_empty())
@@ -1683,9 +1681,7 @@ ViewState ScalarDragBox::tick(ViewContext const & ctx, CRect const & region,
     bool   is_full = false;
     Buffer text{text_};
 
-    auto const sink = [&](Span<char const> str) {
-      is_full = is_full | text.extend(str);
-    };
+    auto const sink = [&](Str str) { is_full = is_full | text.extend(str); };
 
     fmt::Op ops_[fmt::MAX_ARGS];
     Buffer  ops{ops_};
@@ -1773,8 +1769,7 @@ Cursor ScalarDragBox::cursor(CRect const & region, f32, Vec2 offset)
   return state.disabled ? Cursor::Default : Cursor::EWResize;
 }
 
-ScalarBox::ScalarBox(Span<c32 const>   decrease_text,
-                     Span<c32 const>   increase_text,
+ScalarBox::ScalarBox(Str32 decrease_text, Str32 increase_text,
                      TextStyle const & button_text_style,
                      TextStyle const & drag_text_style,
                      FontStyle const & icon_font, FontStyle const & text_font,
@@ -1819,19 +1814,19 @@ ScalarBox & ScalarBox::step(i32 direction)
   return *this;
 }
 
-ScalarBox & ScalarBox::stub(Span<c32 const> text)
+ScalarBox & ScalarBox::stub(Str32 text)
 {
   drag_.input_.stub(text);
   return *this;
 }
 
-ScalarBox & ScalarBox::stub(Span<c8 const> text)
+ScalarBox & ScalarBox::stub(Str8 text)
 {
   drag_.input_.stub(text);
   return *this;
 }
 
-ScalarBox & ScalarBox::format(Span<char const> format)
+ScalarBox & ScalarBox::format(Str format)
 {
   drag_.style.format = format;
   drag_.state.hash   = 0;
@@ -2213,14 +2208,14 @@ Cursor ComboItem::cursor(CRect const &, f32, Vec2)
   return Cursor::Pointer;
 }
 
-TextComboItem::TextComboItem(Span<c32 const> text, TextStyle const & style,
+TextComboItem::TextComboItem(Str32 text, TextStyle const & style,
                              FontStyle const & font, AllocatorRef allocator) :
   text_{text, style, font, allocator}
 {
   text_.copyable(false);
 }
 
-TextComboItem::TextComboItem(Span<c8 const> text, TextStyle const & style,
+TextComboItem::TextComboItem(Str8 text, TextStyle const & style,
                              FontStyle const & font, AllocatorRef allocator) :
   text_{text, style, font, allocator}
 {

--- a/ashura/engine/views.h
+++ b/ashura/engine/views.h
@@ -358,14 +358,14 @@ struct Text : View
 
   TextCompositor compositor_;
 
-  Text(Span<c32 const>   text      = U""_str,
+  Text(Str32             text      = U""_str,
        TextStyle const & style     = TextStyle{.color = theme.on_surface},
        FontStyle const & font      = FontStyle{.font        = theme.body_font,
                                                .height      = theme.body_font_height,
                                                .line_height = theme.line_height},
        AllocatorRef      allocator = default_allocator);
 
-  Text(Span<c8 const>    text,
+  Text(Str8              text,
        TextStyle const & style     = TextStyle{.color = theme.on_surface},
        FontStyle const & font      = FontStyle{.font        = theme.body_font,
                                                .height      = theme.body_font_height,
@@ -387,11 +387,11 @@ struct Text : View
   Text & run(TextStyle const & style, FontStyle const & font, u32 first = 0,
              u32 count = U32_MAX);
 
-  Text & text(Span<c32 const> text);
+  Text & text(Str32 text);
 
-  Text & text(Span<c8 const> text);
+  Text & text(Str8 text);
 
-  Span<c32 const> text();
+  Str32 text();
 
   virtual ViewState tick(ViewContext const & ctx, CRect const & region,
                          f32 zoom, ViewEvents const & events,
@@ -448,14 +448,14 @@ struct Input : View
 
   TextCompositor compositor_;
 
-  Input(Span<c32 const>   stub      = U""_str,
+  Input(Str32             stub      = U""_str,
         TextStyle const & style     = TextStyle{.color = theme.on_surface},
         FontStyle const & font      = FontStyle{.font   = theme.body_font,
                                                 .height = theme.body_font_height,
                                                 .line_height = theme.line_height},
         AllocatorRef      allocator = default_allocator);
 
-  Input(Span<c8 const>    stub,
+  Input(Str8              stub,
         TextStyle const & style     = TextStyle{.color = theme.on_surface},
         FontStyle const & font      = FontStyle{.font   = theme.body_font,
                                                 .height = theme.body_font_height,
@@ -488,16 +488,16 @@ struct Input : View
 
   Input & on_focus_out(Fn<void()> fn);
 
-  Input & content(Span<c8 const> text);
+  Input & content(Str8 text);
 
-  Input & content(Span<c32 const> text);
+  Input & content(Str32 text);
 
   Input & content_run(TextStyle const & style, FontStyle const & font,
                       u32 first = 0, u32 count = U32_MAX);
 
-  Input & stub(Span<c8 const> text);
+  Input & stub(Str8 text);
 
-  Input & stub(Span<c32 const> text);
+  Input & stub(Str32 text);
 
   Input & stub_run(TextStyle const & style, FontStyle const & font,
                    u32 first = 0, u32 count = U32_MAX);
@@ -586,7 +586,7 @@ struct TextButton : Button
   Text text_;
 
   TextButton(
-    Span<c32 const>   text      = U""_str,
+    Str32             text      = U""_str,
     TextStyle const & style     = TextStyle{.color = theme.on_surface},
     FontStyle const & font      = FontStyle{.font        = theme.body_font,
                                             .height      = theme.body_font_height,
@@ -594,8 +594,7 @@ struct TextButton : Button
     AllocatorRef      allocator = default_allocator);
 
   TextButton(
-    Span<c8 const>    text,
-    TextStyle const & style     = TextStyle{.color = theme.on_surface},
+    Str8 text, TextStyle const & style = TextStyle{.color = theme.on_surface},
     FontStyle const & font      = FontStyle{.font        = theme.body_font,
                                             .height      = theme.body_font_height,
                                             .line_height = theme.line_height},
@@ -612,9 +611,9 @@ struct TextButton : Button
   TextButton & run(TextStyle const & style, FontStyle const & font,
                    u32 first = 0, u32 count = U32_MAX);
 
-  TextButton & text(Span<c32 const> text);
+  TextButton & text(Str32 text);
 
-  TextButton & text(Span<c8 const> text);
+  TextButton & text(Str8 text);
 
   TextButton & color(Vec4U8 color);
 
@@ -658,14 +657,14 @@ struct Icon : View
 
   RenderText text_;
 
-  Icon(Span<c32 const>   text      = U""_str,
+  Icon(Str32             text      = U""_str,
        TextStyle const & style     = TextStyle{.color = theme.on_surface},
        FontStyle const & font      = FontStyle{.font        = theme.icon_font,
                                                .height      = theme.body_font_height,
                                                .line_height = theme.line_height},
        AllocatorRef      allocator = default_allocator);
 
-  Icon(Span<c8 const>    text,
+  Icon(Str8              text,
        TextStyle const & style     = TextStyle{.color = theme.on_surface},
        FontStyle const & font      = FontStyle{.font        = theme.icon_font,
                                                .height      = theme.body_font_height,
@@ -680,11 +679,9 @@ struct Icon : View
 
   Icon & hide(bool hide);
 
-  Icon & icon(Span<c8 const> text, TextStyle const & style,
-              FontStyle const & font);
+  Icon & icon(Str8 text, TextStyle const & style, FontStyle const & font);
 
-  Icon & icon(Span<c32 const> text, TextStyle const & style,
-              FontStyle const & font);
+  Icon & icon(Str32 text, TextStyle const & style, FontStyle const & font);
 
   ViewState tick(ViewContext const & ctx, CRect const & region, f32 zoom,
                  ViewEvents const & events, Fn<void(View &)> build) override;
@@ -729,14 +726,14 @@ struct CheckBox : View
 
   Icon icon_;
 
-  CheckBox(Span<c32 const>   text      = U""_str,
+  CheckBox(Str32             text      = U""_str,
            TextStyle const & style     = TextStyle{.color = theme.on_surface},
            FontStyle const & font      = FontStyle{.font   = theme.icon_font,
                                                    .height = theme.body_font_height,
                                                    .line_height = theme.line_height},
            AllocatorRef      allocator = default_allocator);
 
-  CheckBox(Span<c8 const>    text,
+  CheckBox(Str8              text,
            TextStyle const & style     = TextStyle{.color = theme.on_surface},
            FontStyle const & font      = FontStyle{.font   = theme.icon_font,
                                                    .height = theme.body_font_height,
@@ -1065,7 +1062,7 @@ struct ScalarDragBox : View
 
     f32 thickness = 1.0F;
 
-    Span<char const> format = "{}"_str;
+    Str format = "{}"_str;
   } style;
 
   Input input_;
@@ -1092,8 +1089,7 @@ struct ScalarDragBox : View
   ScalarDragBox & operator=(ScalarDragBox &&)      = delete;
   virtual ~ScalarDragBox() override                = default;
 
-  static void scalar_parse(Span<c32 const> text, ScalarInfo const & spec,
-                           Scalar &);
+  static void scalar_parse(Str32 text, ScalarInfo const & spec, Scalar &);
 
   virtual ViewState tick(ViewContext const & ctx, CRect const & region,
                          f32 zoom, ViewEvents const & events,
@@ -1124,8 +1120,7 @@ struct ScalarBox : Flex
   ScalarDragBox drag_;
 
   ScalarBox(
-    Span<c32 const>   decrease_text = U"remove"_str,
-    Span<c32 const>   increase_text = U"add"_str,
+    Str32 decrease_text = U"remove"_str, Str32 increase_text = U"add"_str,
     TextStyle const & button_text_style =
       TextStyle{
         .shadow_scale = 1, .shadow_offset = {1, 1},
@@ -1150,11 +1145,11 @@ struct ScalarBox : Flex
 
   ScalarBox & step(i32 direction);
 
-  ScalarBox & stub(Span<c32 const> text);
+  ScalarBox & stub(Str32 text);
 
-  ScalarBox & stub(Span<c8 const> text);
+  ScalarBox & stub(Str8 text);
 
-  ScalarBox & format(Span<char const> format);
+  ScalarBox & format(Str format);
 
   ScalarBox & spec(f32 scalar, F32Info info);
 
@@ -1376,16 +1371,14 @@ struct TextComboItem : ComboItem
   Text text_;
 
   TextComboItem(
-    Span<c32 const>   text,
-    TextStyle const & style     = TextStyle{.color = theme.on_surface},
+    Str32 text, TextStyle const & style = TextStyle{.color = theme.on_surface},
     FontStyle const & font      = FontStyle{.font        = theme.body_font,
                                             .height      = theme.body_font_height,
                                             .line_height = theme.line_height},
     AllocatorRef      allocator = default_allocator);
 
   TextComboItem(
-    Span<c8 const>    text,
-    TextStyle const & style     = TextStyle{.color = theme.on_surface},
+    Str8 text, TextStyle const & style = TextStyle{.color = theme.on_surface},
     FontStyle const & font      = FontStyle{.font        = theme.body_font,
                                             .height      = theme.body_font_height,
                                             .line_height = theme.line_height},

--- a/ashura/engine/window.cc
+++ b/ashura/engine/window.cc
@@ -47,7 +47,7 @@ struct ClipBoardImpl : ClipBoard
   ClipBoardImpl & operator=(ClipBoardImpl &&)      = delete;
   ~ClipBoardImpl() override                        = default;
 
-  virtual Result<> get(Span<char const> mime, Vec<u8> & out) override
+  virtual Result<> get(Str mime, Vec<u8> & out) override
   {
     char mime_c_str[MAX_MIME_SIZE + 1];
     CHECK(to_c_str(mime, mime_c_str), "");
@@ -83,7 +83,7 @@ struct ClipBoardImpl : ClipBoard
     clipboard.local_.clear();
   }
 
-  virtual Result<> set(Span<char const> mime, Span<u8 const> data) override
+  virtual Result<> set(Str mime, Span<u8 const> data) override
   {
     if (data.is_empty() || mime.is_empty())
     {
@@ -149,8 +149,8 @@ struct WindowSystemImpl : WindowSystem
     return ((WindowImpl *) window)->win;
   }
 
-  virtual Option<Window> create_window(gpu::Instance &  instance,
-                                       Span<char const> title) override
+  virtual Option<Window> create_window(gpu::Instance & instance,
+                                       Str             title) override
   {
     char * title_c_str;
     if (!allocator->nalloc(title.size() + 1, title_c_str))
@@ -203,7 +203,7 @@ struct WindowSystemImpl : WindowSystem
     }
   }
 
-  virtual void set_title(Window window, Span<char const> title) override
+  virtual void set_title(Window window, Str title) override
   {
     char * title_c_str;
     CHECK(allocator->nalloc(title.size() + 1, title_c_str), "");

--- a/ashura/engine/window.h
+++ b/ashura/engine/window.h
@@ -23,12 +23,11 @@ struct WindowSystem
 
   virtual void shutdown() = 0;
 
-  virtual Option<Window> create_window(gpu::Instance &  instance,
-                                       Span<char const> title) = 0;
+  virtual Option<Window> create_window(gpu::Instance & instance, Str title) = 0;
 
   virtual void uninit_window(Window window) = 0;
 
-  virtual void set_title(Window window, Span<char const> title) = 0;
+  virtual void set_title(Window window, Str title) = 0;
 
   virtual char const * get_title(Window window) = 0;
 

--- a/ashura/std/bench/hash_map.cc
+++ b/ashura/std/bench/hash_map.cc
@@ -9,7 +9,7 @@
 
 using namespace ash;
 
-constexpr Span<char const> DATASET[] = {
+constexpr Str DATASET[] = {
   "Lorem"_str,
   "ipsum"_str,
   "dolor"_str,

--- a/ashura/std/fs.cc
+++ b/ashura/std/fs.cc
@@ -9,7 +9,7 @@ namespace ash
 
 constexpr usize PATH_RESERVED_SIZE = 256;
 
-Result<Void, IoErr> read_file(Span<char const> path, Vec<u8> & buff)
+Result<Void, IoErr> read_file(Str path, Vec<u8> & buff)
 {
   u8                reserved[PATH_RESERVED_SIZE];
   FallbackAllocator allocator{to_arena(reserved)};
@@ -68,8 +68,7 @@ Result<Void, IoErr> read_file(Span<char const> path, Vec<u8> & buff)
   return Ok{};
 }
 
-Result<Void, IoErr> write_to_file(Span<char const> path, Span<u8 const> buff,
-                                  bool append)
+Result<Void, IoErr> write_to_file(Str path, Span<u8 const> buff, bool append)
 {
   u8                reserved[PATH_RESERVED_SIZE];
   FallbackAllocator allocator{to_arena(reserved)};

--- a/ashura/std/fs.h
+++ b/ashura/std/fs.h
@@ -62,7 +62,7 @@ enum class [[nodiscard]] IoErr : i32
   TemporarilyUnavailable = EWOULDBLOCK
 };
 
-constexpr Span<char const> to_str(IoErr err)
+constexpr Str to_str(IoErr err)
 {
   if (err == IoErr::None)
   {
@@ -279,8 +279,7 @@ inline void format(fmt::Sink sink, fmt::Spec spec, IoErr const & err)
   return format(sink, spec, to_str(err));
 }
 
-inline Result<> path_join(Span<char const> base, Span<char const> ext,
-                          Vec<char> & out)
+inline Result<> path_join(Str base, Str ext, Vec<char> & out)
 {
   usize const max_size = base.size() + ext.size() + 1;
 
@@ -311,9 +310,8 @@ inline Result<> path_join(Span<char const> base, Span<char const> ext,
   return Ok{};
 }
 
-Result<Void, IoErr> read_file(Span<char const> path, Vec<u8> & buff);
+Result<Void, IoErr> read_file(Str path, Vec<u8> & buff);
 
-Result<Void, IoErr> write_to_file(Span<char const> path, Span<u8 const> buff,
-                                  bool append);
+Result<Void, IoErr> write_to_file(Str path, Span<u8 const> buff, bool append);
 
 }    // namespace ash

--- a/ashura/std/log.cc
+++ b/ashura/std/log.cc
@@ -48,7 +48,7 @@ char const * get_level_str(LogLevel level)
   }
 }
 
-void StdioSink::log(LogLevel level, Span<char const> log_message)
+void StdioSink::log(LogLevel level, Str log_message)
 {
   char const * level_str = get_level_str(level);
   std::FILE *  file      = stdout;
@@ -102,7 +102,7 @@ void StdioSink::flush()
   (void) std::fflush(stderr);
 }
 
-void FileSink::log(LogLevel level, Span<char const> log_message)
+void FileSink::log(LogLevel level, Str log_message)
 {
   char const *                level_str     = get_level_str(level);
   static constexpr char const time_format[] = "%d/%m/%Y, %H:%M:%S";

--- a/ashura/std/log.h
+++ b/ashura/std/log.h
@@ -40,8 +40,8 @@ ASH_BIT_ENUM_OPS(LogLevels)
 
 struct LogSink
 {
-  virtual void log(LogLevel level, Span<char const> log_message) = 0;
-  virtual void flush()                                           = 0;
+  virtual void log(LogLevel level, Str log_message) = 0;
+  virtual void flush()                              = 0;
 };
 
 /// @brief Logger needs to use fixed-size memory as malloc can fail and make
@@ -79,37 +79,37 @@ struct Logger
   }
 
   template <typename... Args>
-  bool debug(Span<char const> fstr, Args const &... args)
+  bool debug(Str fstr, Args const &... args)
   {
     return log(LogLevel::Debug, fstr, args...);
   }
 
   template <typename... Args>
-  bool trace(Span<char const> fstr, Args const &... args)
+  bool trace(Str fstr, Args const &... args)
   {
     return log(LogLevel::Trace, fstr, args...);
   }
 
   template <typename... Args>
-  bool info(Span<char const> fstr, Args const &... args)
+  bool info(Str fstr, Args const &... args)
   {
     return log(LogLevel::Info, fstr, args...);
   }
 
   template <typename... Args>
-  bool warn(Span<char const> fstr, Args const &... args)
+  bool warn(Str fstr, Args const &... args)
   {
     return log(LogLevel::Warning, fstr, args...);
   }
 
   template <typename... Args>
-  bool error(Span<char const> fstr, Args const &... args)
+  bool error(Str fstr, Args const &... args)
   {
     return log(LogLevel::Error, fstr, args...);
   }
 
   template <typename... Args>
-  bool fatal(Span<char const> fstr, Args const &... args)
+  bool fatal(Str fstr, Args const &... args)
   {
     return log(LogLevel::Fatal, fstr, args...);
   }
@@ -123,7 +123,7 @@ struct Logger
   }
 
   template <typename... Args>
-  bool log(LogLevel level, Span<char const> fstr, Args const &... args)
+  bool log(LogLevel level, Str fstr, Args const &... args)
   {
     static_assert(sizeof...(args) <= fmt::MAX_ARGS);
 
@@ -135,7 +135,7 @@ struct Logger
 
     Buffer<fmt::Op> ops{ops_scratch};
 
-    auto format_sink = [&](Span<char const> str) {
+    auto format_sink = [&](Str str) {
       if (!buffer.extend(str))
       {
         for (LogSink * sink : sinks())
@@ -188,7 +188,7 @@ struct Logger
   }
 
   template <typename... Args>
-  [[noreturn]] void panic(Span<char const> fstr, Args const &... args)
+  [[noreturn]] void panic(Str fstr, Args const &... args)
   {
     std::atomic_ref panic_count{*ash::panic_count};
     if (panic_count.fetch_add(1, std::memory_order::relaxed))
@@ -216,7 +216,7 @@ struct StdioSink : LogSink
 {
   std::mutex mutex;
 
-  void log(LogLevel level, Span<char const> log_message) override;
+  void log(LogLevel level, Str log_message) override;
   void flush() override;
 };
 
@@ -227,7 +227,7 @@ struct FileSink : LogSink
   std::FILE * file = nullptr;
   std::mutex  mutex;
 
-  void log(LogLevel level, Span<char const> log_message) override;
+  void log(LogLevel level, Str log_message) override;
   void flush() override;
 };
 
@@ -236,37 +236,37 @@ extern Logger * logger;
 ASH_C_LINKAGE ASH_DLL_EXPORT void hook_logger(Logger *);
 
 template <typename... Args>
-void debug(Span<char const> fstr, Args const &... args)
+void debug(Str fstr, Args const &... args)
 {
   logger->debug(fstr, args...);
 }
 
 template <typename... Args>
-void trace(Span<char const> fstr, Args const &... args)
+void trace(Str fstr, Args const &... args)
 {
   logger->trace(fstr, args...);
 }
 
 template <typename... Args>
-void info(Span<char const> fstr, Args const &... args)
+void info(Str fstr, Args const &... args)
 {
   logger->info(fstr, args...);
 }
 
 template <typename... Args>
-void warn(Span<char const> fstr, Args const &... args)
+void warn(Str fstr, Args const &... args)
 {
   logger->warn(fstr, args...);
 }
 
 template <typename... Args>
-void error(Span<char const> fstr, Args const &... args)
+void error(Str fstr, Args const &... args)
 {
   logger->error(fstr, args...);
 }
 
 template <typename... Args>
-void fatal(Span<char const> fstr, Args const &... args)
+void fatal(Str fstr, Args const &... args)
 {
   logger->fatal(fstr, args...);
 }

--- a/ashura/std/map.h
+++ b/ashura/std/map.h
@@ -547,7 +547,7 @@ struct IsTriviallyRelocatable<Map<K, V, H, KCmp, D>>
 };
 
 template <typename V, typename D = usize>
-using StrMap = Map<Span<char const>, V, SpanHash, StrEq, D>;
+using StrMap = Map<Str, V, SpanHash, StrEq, D>;
 
 template <typename V, typename D = usize>
 using StrVecMap = Map<Vec<char>, V, SpanHash, StrEq, D>;

--- a/ashura/std/mem.h
+++ b/ashura/std/mem.h
@@ -171,7 +171,7 @@ ASH_FORCE_INLINE void prefetch(T const * src, Access rw, Locality locality)
 }    // namespace mem
 
 /// @brief copy non-null-terminated string `str` to `c_str` and null-terminate `c_str`.
-[[nodiscard]] inline bool to_c_str(Span<char const> str, Span<char> c_str)
+[[nodiscard]] inline bool to_c_str(Str str, Span<char> c_str)
 {
   if ((str.size() + 1) > c_str.size()) [[unlikely]]
   {
@@ -285,7 +285,7 @@ struct StrEq
     return mem::eq(a, b);
   }
 
-  bool operator()(Span<c8 const> a, Span<c8 const> b) const
+  bool operator()(Str8 a, Str8 b) const
   {
     return mem::eq(a, b);
   }
@@ -295,7 +295,7 @@ struct StrEq
     return mem::eq(a, b);
   }
 
-  bool operator()(Span<c32 const> a, Span<c32 const> b) const
+  bool operator()(Str32 a, Str32 b) const
   {
     return mem::eq(a, b);
   }

--- a/ashura/std/option.h
+++ b/ashura/std/option.h
@@ -191,8 +191,8 @@ struct [[nodiscard]] Option
     return none;
   }
 
-  constexpr T unwrap(Span<char const> msg = ""_str,
-                     SourceLocation   loc = SourceLocation::current())
+  constexpr T unwrap(Str            msg = ""_str,
+                     SourceLocation loc = SourceLocation::current())
   {
     CHECK_SLOC(loc, is_some(), "Expected Value in Option but got None. {}",
                msg);
@@ -272,8 +272,8 @@ struct [[nodiscard]] Option
     return op();
   }
 
-  constexpr void unwrap_none(Span<char const> msg = ""_str,
-                             SourceLocation   loc = SourceLocation::current())
+  constexpr void unwrap_none(Str            msg = ""_str,
+                             SourceLocation loc = SourceLocation::current())
   {
     CHECK_SLOC(loc, is_none(), "Expected None in Option but got Value = {}. {}",
                value_, msg);
@@ -506,8 +506,8 @@ struct [[nodiscard]] OptionRef
     return *rep_;
   }
 
-  constexpr T & unwrap(Span<char const> msg = ""_str,
-                       SourceLocation   loc = SourceLocation::current())
+  constexpr T & unwrap(Str            msg = ""_str,
+                       SourceLocation loc = SourceLocation::current())
   {
     CHECK_SLOC(loc, is_some(), "Expected Value in OptionRef but got None. {}",
                msg);
@@ -523,8 +523,8 @@ struct [[nodiscard]] OptionRef
     return alt;
   }
 
-  constexpr void unwrap_none(Span<char const> msg = ""_str,
-                             SourceLocation   loc = SourceLocation::current())
+  constexpr void unwrap_none(Str            msg = ""_str,
+                             SourceLocation loc = SourceLocation::current())
   {
     CHECK_SLOC(loc, is_none(),
                "Expected None in OptionRef but got Value = {}. {}", *rep_, msg);

--- a/ashura/std/result.h
+++ b/ashura/std/result.h
@@ -336,16 +336,16 @@ struct [[nodiscard]] Result
     return static_cast<Fn &&>(op)(err_);
   }
 
-  constexpr T unwrap(Span<char const> msg = ""_str,
-                     SourceLocation   loc = SourceLocation::current())
+  constexpr T unwrap(Str            msg = ""_str,
+                     SourceLocation loc = SourceLocation::current())
   {
     CHECK_SLOC(loc, is_ok(), "Expected Value in Result but got Err = {}. {}",
                err_, msg);
     return static_cast<T &&>(value_);
   }
 
-  constexpr E unwrap_err(Span<char const> msg = ""_str,
-                         SourceLocation   loc = SourceLocation::current())
+  constexpr E unwrap_err(Str            msg = ""_str,
+                         SourceLocation loc = SourceLocation::current())
   {
     CHECK_SLOC(loc, is_err(), "Expected Err in Result but got Value = {}. {}",
                value_, msg);

--- a/ashura/std/text.h
+++ b/ashura/std/text.h
@@ -9,11 +9,11 @@
 namespace ash
 {
 
-[[nodiscard]] constexpr bool is_valid_utf8(Span<c8 const> text);
+[[nodiscard]] constexpr bool is_valid_utf8(Str8 text);
 
 /// @brief count number of utf8 codepoints found in the text. does no
 /// utf8-validation
-[[nodiscard]] constexpr usize count_utf8_codepoints(Span<c8 const> text)
+[[nodiscard]] constexpr usize count_utf8_codepoints(Str8 text)
 {
   c8 const * in    = text.data();
   c8 const * end   = text.pend();
@@ -31,8 +31,7 @@ namespace ash
 
 /// @brief decoded.size() must be at least count_utf8_codepoints(encoded).
 /// estimate: encoded.size()
-[[nodiscard]] constexpr usize utf8_decode(Span<c8 const> encoded,
-                                          Span<c32>      decoded)
+[[nodiscard]] constexpr usize utf8_decode(Str8 encoded, Span<c32> decoded)
 {
   c8 const * in  = encoded.data();
   c8 const * end = encoded.pend();
@@ -70,8 +69,7 @@ namespace ash
 }
 
 /// @brief encoded.size must be at least decoded.size * 4
-[[nodiscard]] constexpr usize utf8_encode(Span<c32 const> decoded,
-                                          Span<c8>        encoded)
+[[nodiscard]] constexpr usize utf8_encode(Str32 decoded, MutStr8 encoded)
 {
   c8 *        out = encoded.data();
   c32 const * in  = decoded.data();
@@ -112,7 +110,7 @@ namespace ash
 
 /// @brief converts UTF-8 text from @p encoded to UTF-32 and appends into @p
 /// `decoded`
-inline Result<> utf8_decode(Span<c8 const> encoded, Vec<c32> & decoded)
+inline Result<> utf8_decode(Str8 encoded, Vec<c32> & decoded)
 {
   usize const first = decoded.size();
   usize const count = count_utf8_codepoints(encoded);
@@ -126,8 +124,7 @@ inline Result<> utf8_decode(Span<c8 const> encoded, Vec<c32> & decoded)
 
 /// @brief converts UTF-32 text from @p decoded to UTF-8 and appends into @p
 /// `encoded`
-[[nodiscard]] inline Result<> utf8_encode(Span<c32 const> decoded,
-                                          Vec<c8> &       encoded)
+[[nodiscard]] inline Result<> utf8_encode(Str32 decoded, Vec<c8> & encoded)
 {
   usize const first     = encoded.size();
   usize const max_count = decoded.size();
@@ -141,8 +138,8 @@ inline Result<> utf8_decode(Span<c8 const> encoded, Vec<c32> & decoded)
   return Ok{};
 }
 
-constexpr void replace_invalid_codepoints(Span<c32 const> input,
-                                          Span<c32> output, c32 replacement)
+constexpr void replace_invalid_codepoints(Str32 input, Span<c32> output,
+                                          c32 replacement)
 {
   c32 const * in  = input.pbegin();
   c32 const * end = input.pend();

--- a/ashura/std/trace.h
+++ b/ashura/std/trace.h
@@ -12,7 +12,7 @@ namespace ash
 
 struct TraceRecord
 {
-  Span<char const> label = {};
+  Str label = {};
 
   u64 id = 0;
 
@@ -29,7 +29,7 @@ struct TraceRecord
 
 struct TraceEvent
 {
-  Span<char const> label = {};
+  Str label = {};
 
   u64 id = 0;
 };

--- a/ashura/std/types.h
+++ b/ashura/std/types.h
@@ -1314,27 +1314,31 @@ constexpr auto view(R & range) -> decltype(range.view())
   return range.view();
 }
 
+typedef Span<char const> Str;
+typedef Span<char>       MutStr;
+
+typedef Span<c8 const> Str8;
+typedef Span<c8>       MutStr8;
+
+typedef Span<c32 const> Str32;
+typedef Span<c32>       MutStr32;
+
 inline namespace str_literal
 {
 
-constexpr Span<char const> operator""_str(char const * lit, usize n)
+constexpr Str operator""_str(char const * lit, usize n)
 {
-  return Span<char const>{lit, n};
+  return Str{lit, n};
 }
 
-constexpr Span<c8 const> operator""_str(c8 const * lit, usize n)
+constexpr Str8 operator""_str(c8 const * lit, usize n)
 {
-  return Span<c8 const>{lit, n};
+  return Str8{lit, n};
 }
 
-constexpr Span<c16 const> operator""_str(c16 const * lit, usize n)
+constexpr Str32 operator""_str(c32 const * lit, usize n)
 {
-  return Span<c16 const>{lit, n};
-}
-
-constexpr Span<c32 const> operator""_str(c32 const * lit, usize n)
-{
-  return Span<c32 const>{lit, n};
+  return Str32{lit, n};
 }
 
 }    // namespace str_literal
@@ -2201,18 +2205,18 @@ struct SourceLocation
   static constexpr SourceLocation current(
 #if ASH_HAS_BUILTIN(FILE) || (defined(__cpp_lib_source_location) && \
                               __cpp_lib_source_location >= 201'907L)
-    Span<char const> file = cstr_span(__builtin_FILE()),
+    Str file = cstr_span(__builtin_FILE()),
 #elif defined(__FILE__)
-    Span<char const> file = cstr_span(__FILE__),
+    Str file = cstr_span(__FILE__),
 #else
-    Span<char const> file = cstr_span("unknown"),
+    Str file = cstr_span("unknown"),
 #endif
 
 #if ASH_HAS_BUILTIN(FUNCTION) || (defined(__cpp_lib_source_location) && \
                                   __cpp_lib_source_location >= 201'907L)
-    Span<char const> function = cstr_span(__builtin_FUNCTION()),
+    Str function = cstr_span(__builtin_FUNCTION()),
 #else
-    Span<char const> function = cstr_span("unknown"),
+    Str function = cstr_span("unknown"),
 #endif
 
 #if ASH_HAS_BUILTIN(LINE) || (defined(__cpp_lib_source_location) && \
@@ -2235,10 +2239,10 @@ struct SourceLocation
     return SourceLocation{file, function, line, column};
   }
 
-  Span<char const> file     = ""_str;
-  Span<char const> function = ""_str;
-  u32              line     = 0;
-  u32              column   = 0;
+  Str file     = ""_str;
+  Str function = ""_str;
+  u32 line     = 0;
+  u32 column   = 0;
 };
 
 template <typename T = void>


### PR DESCRIPTION
This replaces all intended uses of strings: previously `Span<char const>`, `Span<c8 const>` or `Span<c32 const>` with aliases `Str`, `Str8`, and `Str32` respectively.